### PR TITLE
Scaffold repo: TypeScript + esbuild bundle, CI, release workflow

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "add-reasoning-to-prs",
+  "displayName": "Add Reasoning to PRs",
+  "description": "Writes a forward-only \"why\" block (decisions, trade-offs, assumptions, limitations) into your PR description or commit message at PR-create / direct-push time — composed by your own agent, in-session, with no account and no server round-trip.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Backthread"
+  },
+  "homepage": "https://backthread.dev"
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Dependabot — propose bumps for the SHA-pinned GitHub Actions and the npm devDeps.
+# CI pins actions by commit SHA; Dependabot keeps those pins current (with the human-
+# readable version in the trailing comment) so security fixes don't go stale.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+# CI — typecheck + test on every PR and push to main, verify the committed self-contained
+# bundle is in sync with src, and hold the supply-chain floor for a widely-`npx`'d
+# package: a vulnerability gate, a lockfile-integrity gate, and a guard that the release
+# keeps npm provenance on.
+#
+# GitHub Actions are PINNED BY COMMIT SHA (not a floating tag) so a compromised/retagged
+# action can't silently run in CI; Dependabot (.github/dependabot.yml) proposes bumps.
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+      # Lockfile integrity: it must be present, and `npm ci` (below) hard-fails if it's
+      # out of sync with package.json — so an un-committed dependency change can't slip
+      # through.
+      - name: Lockfile present
+        run: test -f package-lock.json || { echo "::error::package-lock.json is missing — commit it (npm install)."; exit 1; }
+      - name: Install (npm ci — fails on a drifted lockfile)
+        run: npm ci
+      # Vulnerability gate: fail the build on a HIGH+ advisory anywhere in the tree.
+      - name: Vulnerability gate (npm audit, high+)
+        run: npm audit --audit-level=high
+      - name: Typecheck
+        run: npm run typecheck
+      # `npm test` runs the unit suite + `npm run build` + `npm run smoke`, and the smoke
+      # step regenerates dist-bundle/add-reasoning-to-prs.js — so the sync check below
+      # compares the committed bundle against a fresh build.
+      - name: Test
+        run: npm test
+      # The Claude Code plugin is cloned from git with NO build step on install, so the
+      # COMMITTED bundle must equal a fresh build. `npm test` just rebuilt it; fail if it
+      # differs from what's committed (esbuild is deterministic for the pinned version).
+      - name: Committed bundle is in sync with src
+        run: git diff --exit-code dist-bundle/add-reasoning-to-prs.js
+      # Regression guard: every release workflow must keep npm build provenance on, so
+      # each published package always carries a verifiable, tamper-evident attestation.
+      - name: Releases keep npm provenance on
+        run: |
+          for wf in .github/workflows/release*.yml; do
+            grep -Eq 'npm publish[^#]*--provenance' "$wf" \
+              || { echo "::error::$wf's npm publish must keep --provenance"; exit 1; }
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+# Release — on a `v*` tag: test → verify the tag matches package.json → publish
+# `add-reasoning-to-prs` to npm via OIDC TRUSTED PUBLISHING → cut a GitHub Release with
+# auto-generated notes.
+#
+# SETUP (founder, one-time, NO TOKEN): on npmjs.com → the package → Settings → Trusted
+# Publisher, add a GitHub Actions publisher:
+#   Organization or user: backthread   Repository: add-reasoning-to-prs
+#   Workflow filename:    release.yml   Environment name: release
+#   Allowed actions:      Allow npm publish
+# Trusted publishing exchanges THIS workflow's short-lived OIDC token for an npm
+# credential at publish time — no NPM_TOKEN secret, no 2FA OTP, nothing to rotate.
+#
+# To cut a release:
+#   1. bump the version in package.json AND .claude-plugin/plugin.json (the version-
+#      lockstep test enforces they match) + rebuild the bundle (`npm run bundle`),
+#      commit, merge.
+#   2. `git tag v<version> && git push origin v<version>`  (tag MUST match the version).
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+# id-token: write → the OIDC token that trusted publishing + provenance need.
+# contents: write → create the GitHub Release.
+permissions:
+  contents: write
+  id-token: write
+
+# Serialize releases so two tags pushed close together can't race the npm publish.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # MUST equal the "Environment name" set on the npm Trusted Publisher. GitHub
+    # auto-creates this environment on first use; add protection rules (e.g. required
+    # reviewers) to it later for a manual approval gate before each publish.
+    environment: release
+    steps:
+      # SHA-pinned (not floating tags) — see ci.yml + .github/dependabot.yml.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: npm
+      # OIDC trusted publishing needs npm >= 11.5.1; Node 22 ships npm 10.x. Pinned to
+      # 11.18.0 (the last 11.x) rather than @latest: npm 12.0.0 regressed
+      # `npm publish --provenance` (its bundled libnpmpublish can't resolve sigstore).
+      - name: Upgrade npm (OIDC trusted publishing needs >= 11.5.1)
+        run: npm install -g npm@11.18.0
+      - run: npm ci
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Test
+        run: npm test
+      - name: Committed bundle is in sync with src
+        run: git diff --exit-code dist-bundle/add-reasoning-to-prs.js
+      # Guard: the tag must match package.json (and the plugin manifest, via the lockstep
+      # test above) — never publish a version that doesn't match the tag.
+      - name: Tag matches package.json version
+        run: |
+          PKG="v$(node -p "require('./package.json').version")"
+          if [ "$PKG" != "$GITHUB_REF_NAME" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME != package.json ($PKG). Bump package.json + the plugin manifest to match the tag." >&2
+            exit 1
+          fi
+      # `npm publish` runs `prepack` (build + bundle), so the published bin is always a
+      # fresh self-contained bundle. With OIDC trusted publishing npm authenticates via
+      # the workflow's id-token (no NODE_AUTH_TOKEN) and auto-attaches build provenance.
+      - name: Publish to npm (OIDC trusted publishing)
+        run: npm publish --provenance --access public
+      - name: GitHub Release (auto-generated notes)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" --generate-notes --title "$GITHUB_REF_NAME"

--- a/dist-bundle/add-reasoning-to-prs.js
+++ b/dist-bundle/add-reasoning-to-prs.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+// src/version.ts
+var VERSION = "0.1.0" ? "0.1.0" : readPackageVersion();
+
+// src/cli.ts
+function help() {
+  return `add-reasoning-to-prs ${VERSION}
+
+A Claude Code hook that writes a forward-only "why" block \u2014 the decisions, trade-offs,
+assumptions, and limitations behind a change \u2014 into your PR description (or your commit
+message on a direct push) at the moment the PR is opened.
+
+Usage:
+  add-reasoning-to-prs --version    Print the version and exit
+  add-reasoning-to-prs --help       Show this help
+
+Install into Claude Code:
+  npx add-reasoning-to-prs
+`;
+}
+async function run(argv) {
+  const args = argv.slice(2);
+  const cmd = args[0];
+  if (cmd === "--version" || cmd === "-v" || cmd === "version") {
+    process.stdout.write(VERSION + "\n");
+    return 0;
+  }
+  process.stdout.write(help());
+  return 0;
+}
+
+// src/bin/add-reasoning-to-prs.ts
+run(process.argv).then((code) => process.exit(code)).catch(() => process.exit(0));

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,0 +1,36 @@
+// esbuild.config.mjs — the self-contained distribution build.
+//
+// `npm run build` (tsc) is the DEV / typecheck path: it emits the multi-file `dist/`.
+// This script is the DISTRIBUTION path: it bundles the `add-reasoning-to-prs` bin into a
+// SINGLE self-contained ESM file at `dist-bundle/add-reasoning-to-prs.js` that runs with
+// NO `npm install`. That artifact is what the Claude Code plugin references via
+// `${CLAUDE_PLUGIN_ROOT}` and what `npx add-reasoning-to-prs` executes.
+//
+// The bin has ZERO runtime dependencies (the why-block is composed by the live agent in
+// the session; the hook itself is pure Node string/JSON work), so there is nothing heavy
+// to tree-shake — Node builtins stay external and the bundle is small.
+import { build } from 'esbuild';
+import { readFileSync } from 'node:fs';
+
+// Inline the package version at BUILD time so the bundled bin reports it correctly. A
+// RUNTIME package.json read is unreliable from a self-contained bundle (its on-disk
+// neighbour depends on how the package was installed), so we `define` it as a compile-
+// time constant (version.ts has a dev/tsx fallback for the non-bundled path).
+const { version } = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
+
+await build({
+  entryPoints: ['src/bin/add-reasoning-to-prs.ts'],
+  outfile: 'dist-bundle/add-reasoning-to-prs.js',
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  // Match the package's Node 22 pin (engines).
+  target: 'node22',
+  // Inline the package version (read above) so the bundled bin reports it correctly.
+  define: { __PKG_VERSION__: JSON.stringify(version) },
+  // No banner: src/bin/add-reasoning-to-prs.ts already starts with `#!/usr/bin/env node`,
+  // and esbuild preserves a leading entry-point shebang on line 1. A banner would
+  // duplicate it onto line 2 and break execution.
+  legalComments: 'none',
+  logLevel: 'info',
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,574 @@
+{
+  "name": "add-reasoning-to-prs",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "add-reasoning-to-prs",
+      "version": "0.1.0",
+      "license": "MIT",
+      "bin": {
+        "add-reasoning-to-prs": "dist-bundle/add-reasoning-to-prs.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.19.19",
+        "esbuild": "^0.28.0",
+        "tsx": "^4.22.3",
+        "typescript": "^5.6.2"
+      },
+      "engines": {
+        "node": ">=22.18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "add-reasoning-to-prs",
+  "version": "0.1.0",
+  "description": "A Claude Code hook that writes a forward-only \"why\" block (decisions, trade-offs, assumptions, limitations) into your PR description or commit message at PR-create / direct-push time.",
+  "license": "MIT",
+  "author": "Backthread",
+  "homepage": "https://backthread.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/backthread/add-reasoning-to-prs.git"
+  },
+  "bugs": "https://github.com/backthread/add-reasoning-to-prs/issues",
+  "keywords": [
+    "claude-code",
+    "claude",
+    "hook",
+    "pull-request",
+    "pr-description",
+    "commit-message",
+    "decision-log",
+    "ai-coding-agent",
+    "developer-tools",
+    "cli"
+  ],
+  "type": "module",
+  "comment": "PUBLISHED BIN = the self-contained esbuild bundle (dist-bundle/add-reasoning-to-prs.js), committed to git. The Claude Code plugin references it via ${CLAUDE_PLUGIN_ROOT} and CC runs no build step on install, so the bundle must be tracked. It has ZERO runtime dependencies (the why-block is composed by the live agent in-session; the hook itself is pure Node), so `npx add-reasoning-to-prs` stays fast and install-free.",
+  "bin": {
+    "add-reasoning-to-prs": "./dist-bundle/add-reasoning-to-prs.js"
+  },
+  "files": [
+    "dist-bundle",
+    "hooks",
+    ".claude-plugin",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "bundle": "node esbuild.config.mjs",
+    "prepack": "npm run build && npm run bundle",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
+    "start": "tsx src/bin/add-reasoning-to-prs.ts",
+    "smoke": "npm run bundle && node dist-bundle/add-reasoning-to-prs.js --version > /dev/null",
+    "test": "node --import tsx --test --test-force-exit src/*.test.ts && npm run build && npm run smoke"
+  },
+  "engines": {
+    "node": ">=22.18"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.19",
+    "esbuild": "^0.28.0",
+    "tsx": "^4.22.3",
+    "typescript": "^5.6.2"
+  }
+}

--- a/src/bin/add-reasoning-to-prs.ts
+++ b/src/bin/add-reasoning-to-prs.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+// The `add-reasoning-to-prs` bin entrypoint. Kept thin: it dispatches argv through the
+// pure `run` function (unit-tested without spawning a process) and maps the result to an
+// exit code. esbuild bundles THIS file into the single self-contained
+// dist-bundle/add-reasoning-to-prs.js that the Claude Code plugin and `npx` invoke.
+//
+// FAIL-OPEN posture: this tool must NEVER disrupt the user's git workflow, so a thrown
+// error degrades to a clean exit 0 rather than surfacing a crash to the caller.
+import { run } from '../cli.js';
+
+run(process.argv)
+  .then((code) => process.exit(code))
+  .catch(() => process.exit(0));

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -9,7 +9,6 @@ async function withCapturedStdout(
 ): Promise<{ code: number; out: string }> {
   const chunks: string[] = [];
   const orig = process.stdout.write.bind(process.stdout);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (process.stdout as unknown as { write: (c: unknown) => boolean }).write = (c: unknown) => {
     chunks.push(String(c));
     return true;

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { run } from './cli.js';
+import { VERSION } from './version.js';
+
+/** Run `fn` with process.stdout.write captured, returning the exit code + written text. */
+async function withCapturedStdout(
+  fn: () => Promise<number>,
+): Promise<{ code: number; out: string }> {
+  const chunks: string[] = [];
+  const orig = process.stdout.write.bind(process.stdout);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stdout as unknown as { write: (c: unknown) => boolean }).write = (c: unknown) => {
+    chunks.push(String(c));
+    return true;
+  };
+  try {
+    const code = await fn();
+    return { code, out: chunks.join('') };
+  } finally {
+    process.stdout.write = orig;
+  }
+}
+
+test('--version prints the version and exits 0', async () => {
+  const { code, out } = await withCapturedStdout(() => run(['node', 'bin', '--version']));
+  assert.equal(code, 0);
+  assert.equal(out.trim(), VERSION);
+});
+
+test('-v is an alias for --version', async () => {
+  const { code, out } = await withCapturedStdout(() => run(['node', 'bin', '-v']));
+  assert.equal(code, 0);
+  assert.equal(out.trim(), VERSION);
+});
+
+test('no args prints usage and exits 0', async () => {
+  const { code, out } = await withCapturedStdout(() => run(['node', 'bin']));
+  assert.equal(code, 0);
+  assert.match(out, /add-reasoning-to-prs/);
+  assert.match(out, /Usage:/);
+});
+
+test('--help prints usage and exits 0', async () => {
+  const { code, out } = await withCapturedStdout(() => run(['node', 'bin', '--help']));
+  assert.equal(code, 0);
+  assert.match(out, /Usage:/);
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,45 @@
+// cli.ts — the pure `add-reasoning-to-prs` command dispatcher.
+//
+// Kept side-effect-free (no process.exit, no auto-run) so it can be unit-tested by
+// calling `run()` directly. The thin bin entrypoint (bin/add-reasoning-to-prs.ts) maps
+// its return value to a process exit code.
+//
+// v1 (scaffold) handles only --version / --help. Later work adds the `hook` subcommand
+// (the PreToolUse handler Claude Code invokes) and `install`.
+
+import { VERSION } from './version.js';
+
+export function help(): string {
+  return `add-reasoning-to-prs ${VERSION}
+
+A Claude Code hook that writes a forward-only "why" block — the decisions, trade-offs,
+assumptions, and limitations behind a change — into your PR description (or your commit
+message on a direct push) at the moment the PR is opened.
+
+Usage:
+  add-reasoning-to-prs --version    Print the version and exit
+  add-reasoning-to-prs --help       Show this help
+
+Install into Claude Code:
+  npx add-reasoning-to-prs
+`;
+}
+
+/**
+ * Dispatch a CLI invocation. Takes the full `process.argv` (argv[0]=node, argv[1]=bin),
+ * writes any output, and resolves to the intended exit code. Async so later subcommands
+ * (which read stdin / touch the filesystem) fit without changing the entrypoint.
+ */
+export async function run(argv: string[]): Promise<number> {
+  const args = argv.slice(2);
+  const cmd = args[0];
+
+  if (cmd === '--version' || cmd === '-v' || cmd === 'version') {
+    process.stdout.write(VERSION + '\n');
+    return 0;
+  }
+
+  // Default (no args) and explicit help both print usage.
+  process.stdout.write(help());
+  return 0;
+}

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -1,0 +1,26 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { VERSION } from './version.js';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const readJson = (rel: string): Record<string, unknown> =>
+  JSON.parse(readFileSync(join(root, rel), 'utf8'));
+
+test('VERSION matches package.json', () => {
+  assert.equal(VERSION, readJson('package.json').version);
+});
+
+// Version lockstep: the Claude Code plugin manifest ships alongside the package, so its
+// version must track package.json. CI runs this; a release bumps both together.
+test('plugin manifest version is in lockstep with package.json', () => {
+  const pkg = readJson('package.json');
+  const plugin = readJson('.claude-plugin/plugin.json');
+  assert.equal(
+    plugin.version,
+    pkg.version,
+    'update .claude-plugin/plugin.json "version" to match package.json',
+  );
+});

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,32 @@
+// version.ts — the package version, embedded at BUILD time.
+//
+// The published bin is a single self-contained esbuild bundle; a runtime read of
+// package.json from inside that bundle is unreliable (its on-disk neighbour depends on
+// how the package was installed). So esbuild `define`s __PKG_VERSION__ from package.json
+// at bundle time (see esbuild.config.mjs). The dev/tsx path (no bundle, no define) falls
+// back to reading package.json relative to this module.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// Replaced by esbuild `define` in the bundled bin. Undeclared on the dev/tsx path — but
+// `typeof` on an undeclared identifier is safe (yields 'undefined', never throws).
+declare const __PKG_VERSION__: string;
+
+function readPackageVersion(): string {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    // dev/tsx layout: src/version.ts -> ../package.json
+    const pkg = JSON.parse(readFileSync(join(here, '..', 'package.json'), 'utf8')) as {
+      version?: unknown;
+    };
+    if (typeof pkg.version === 'string' && pkg.version) return pkg.version;
+  } catch {
+    // fall through to the sentinel below
+  }
+  return '0.0.0';
+}
+
+export const VERSION: string =
+  typeof __PKG_VERSION__ === 'string' && __PKG_VERSION__ ? __PKG_VERSION__ : readPackageVersion();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["node"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src"],
+  "exclude": []
+}


### PR DESCRIPTION
## Scaffold the `add-reasoning-to-prs` package

Sets up the standalone TypeScript package for the Claude Code hook and packages it as a self-contained `npx` bin, shipped as a committed, zero-dependency bundle.

### What's here
- **Self-contained bundle.** esbuild produces a single committed file at `dist-bundle/add-reasoning-to-prs.js` — the entrypoint the Claude Code plugin references via `${CLAUDE_PLUGIN_ROOT}` and that `npx` runs. **Zero runtime dependencies** (the "why" block is composed by the live agent in-session; the hook itself is pure Node), so `npx add-reasoning-to-prs` stays fast and install-free.
- **CLI.** `--version` / `-v` and `--help` today; the `hook` subcommand (the `PreToolUse` handler) and `install` land in follow-ups.
- **Tests.** `node:test` unit suite for the CLI, plus a version-lockstep test asserting `package.json` and the plugin manifest stay in sync.
- **CI** (`.github/workflows/ci.yml`): lockfile-integrity gate, `npm audit --audit-level=high`, typecheck, test, a check that the committed bundle equals a fresh build, and a guard that the release keeps `--provenance`. GitHub Actions are SHA-pinned; Dependabot proposes bumps.
- **Release** (`.github/workflows/release.yml`): on a `v*` tag, publishes to npm via OIDC trusted publishing with build provenance, then cuts a GitHub Release. Publishing is deliberately gated behind a tag push.
- MIT license, `0.x` line, minimal README stub (full docs come later).

### Done when
- `add-reasoning-to-prs --version` runs from the **built bundle** — verified: the bundle prints the version, preserves its shebang, and is directly executable.
- CI green.

### Testing
- `npm run typecheck` — clean.
- `npm test` — 6/6 pass; build + smoke (fresh bundle) succeed.
- `node dist-bundle/add-reasoning-to-prs.js --version` → prints the version.
- esbuild writes the bundle at mode `0755` deterministically (shebang), so the committed-bundle sync check is stable across rebuilds.

