### PR TITLE
PreToolUse/Bash hook harness + why-block injection

### DIFF
--- a/dist-bundle/add-reasoning-to-prs.js
+++ b/dist-bundle/add-reasoning-to-prs.js
@@ -3,6 +3,192 @@
 // src/version.ts
 var VERSION = "0.1.0" ? "0.1.0" : readPackageVersion();
 
+// src/stdin.ts
+async function readRawStdin(env = process.env, stdin = process.stdin) {
+  const fromEnv = env.ADD_REASONING_TO_PRS_HOOK_INPUT;
+  if (fromEnv && fromEnv.trim().length > 0) return fromEnv;
+  if (stdin.isTTY) return "";
+  return new Promise((resolve) => {
+    let data = "";
+    stdin.setEncoding("utf8");
+    stdin.on("data", (chunk) => data += chunk);
+    stdin.on("end", () => resolve(data));
+    stdin.on("error", () => resolve(data));
+  });
+}
+
+// src/command.ts
+import { basename } from "node:path";
+var SEGMENT_SPLIT = /&&|\|\||[;\n|&]/;
+var GIT_GLOBAL_OPTS_WITH_VALUE = /* @__PURE__ */ new Set([
+  "-C",
+  "-c",
+  "--git-dir",
+  "--work-tree",
+  "--namespace",
+  "--exec-path"
+]);
+function classifyCommand(command) {
+  if (typeof command !== "string" || command.trim().length === 0) return "other";
+  for (const segment of command.split(SEGMENT_SPLIT)) {
+    const kind = classifySegment(segment);
+    if (kind !== "other") return kind;
+  }
+  return "other";
+}
+function classifySegment(segment) {
+  const tokens = segment.trim().split(/\s+/).filter(Boolean);
+  let i = 0;
+  while (i < tokens.length && (/^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i]) || tokens[i] === "env")) {
+    i++;
+  }
+  if (i >= tokens.length) return "other";
+  const prog = basename(tokens[i]);
+  if (prog === "git") {
+    for (let j = i + 1; j < tokens.length; j++) {
+      const t = tokens[j];
+      if (t.startsWith("-")) {
+        if (GIT_GLOBAL_OPTS_WITH_VALUE.has(t)) j++;
+        continue;
+      }
+      return t === "commit" ? "git-commit" : "other";
+    }
+    return "other";
+  }
+  if (prog === "gh") {
+    const words = tokens.slice(i + 1).filter((t) => !t.startsWith("-"));
+    return words[0] === "pr" && words[1] === "create" ? "gh-pr-create" : "other";
+  }
+  return "other";
+}
+
+// src/marker.ts
+var MARKER_TOKEN = "backthread:why";
+var PR_MARKER_OPEN = "<!-- backthread:why -->";
+var PR_MARKER_CLOSE = "<!-- /backthread:why -->";
+var COMMIT_MARKER_OPEN = "--- backthread:why ---";
+var COMMIT_MARKER_CLOSE = "--- backthread:why end ---";
+function hasMarker(text) {
+  if (typeof text !== "string" || text.length === 0) return false;
+  return text.includes(MARKER_TOKEN);
+}
+
+// src/git.ts
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+var pexec = promisify(execFile);
+async function git(args, cwd) {
+  try {
+    const { stdout } = await pexec("git", args, { cwd, timeout: 3e3, windowsHide: true });
+    return stdout.trim();
+  } catch {
+    return null;
+  }
+}
+async function currentBranch(cwd) {
+  return git(["symbolic-ref", "--quiet", "--short", "HEAD"], cwd);
+}
+async function defaultBranch(cwd) {
+  const head = await git(["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd);
+  if (head) return head.replace(/^origin\//, "");
+  return null;
+}
+async function isDefaultBranch(cwd) {
+  const current = await currentBranch(cwd);
+  if (!current) return false;
+  const def = await defaultBranch(cwd);
+  if (def) return current === def;
+  return current === "main" || current === "master";
+}
+
+// src/guidance.ts
+function surfaceCopy(surface) {
+  if (surface === "pr") {
+    return {
+      open: PR_MARKER_OPEN,
+      close: PR_MARKER_CLOSE,
+      moment: "this pull request is opened",
+      where: "the pull request description (the --body / --body-file text)"
+    };
+  }
+  return {
+    open: COMMIT_MARKER_OPEN,
+    close: COMMIT_MARKER_CLOSE,
+    moment: "this commit lands on the default branch",
+    where: "the commit message body"
+  };
+}
+function buildGuidance(surface) {
+  const c = surfaceCopy(surface);
+  return `add-reasoning-to-prs: before ${c.moment}, add a short, forward-only "why" block to ${c.where}, then re-run the command.
+
+Compose the block ONLY from what you actually decided in THIS session \u2014 never invent. Include only the sections that genuinely apply, and drop any that don't:
+
+- Decisions \u2014 the choices you made and why (not what changed; the diff already shows that).
+- Assumptions \u2014 what you took as given that a reviewer should confirm.
+- Trade-offs \u2014 what you knowingly gave up, and the alternative you rejected.
+- Limitations \u2014 known gaps, risks, or follow-ups you're deliberately deferring.
+
+Rules:
+- Forward-only: capture what the diff can't show \u2014 the why, and the risks knowingly taken. Never summarize the changes.
+- Grounded: every line must trace to real deliberation in this session. Cut anything padded, generic, or inferred.
+- If the session had no genuine decisions to record, that's fine \u2014 leave it out rather than manufacture filler.
+- Keep it tight: a few lines per section at most.
+- Wrap the block EXACTLY between these two markers so it is detected and left untouched on later runs:
+
+${c.open}
+Decisions:
+- <one concise line per decision>
+Trade-offs:
+- <...>
+${c.close}
+
+Then re-run your original command with the block included in ${c.where}.`;
+}
+
+// src/hook.ts
+async function runHook(rawStdin, deps = {}) {
+  try {
+    let payload;
+    try {
+      payload = JSON.parse(rawStdin);
+    } catch {
+      return {};
+    }
+    const rec = payload && typeof payload === "object" ? payload : {};
+    if (rec.tool_name !== void 0 && rec.tool_name !== "Bash") return {};
+    const toolInput = rec.tool_input;
+    const command = toolInput && typeof toolInput === "object" ? toolInput.command : void 0;
+    if (typeof command !== "string" || command.trim().length === 0) return {};
+    const kind = classifyCommand(command);
+    if (kind === "other") return {};
+    if (hasMarker(command)) return {};
+    const cwd = typeof rec.cwd === "string" && rec.cwd ? rec.cwd : deps.cwd ?? process.cwd();
+    let surface;
+    if (kind === "gh-pr-create") {
+      surface = "pr";
+    } else {
+      const onDefault = await (deps.isDefaultBranchImpl ?? isDefaultBranch)(cwd).catch(() => false);
+      if (!onDefault) return {};
+      surface = "commit";
+    }
+    const guidance = buildGuidance(surface);
+    return {
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: guidance,
+        // Progressive enhancement. Claude Code exposes no version signal to hooks, so we
+        // always emit additionalContext too: newer versions surface it, older ones ignore
+        // the unknown field, and the reason above carries the guidance either way.
+        additionalContext: guidance
+      }
+    };
+  } catch {
+    return {};
+  }
+}
+
 // src/cli.ts
 function help() {
   return `add-reasoning-to-prs ${VERSION}
@@ -24,6 +210,12 @@ async function run(argv) {
   const cmd = args[0];
   if (cmd === "--version" || cmd === "-v" || cmd === "version") {
     process.stdout.write(VERSION + "\n");
+    return 0;
+  }
+  if (cmd === "hook") {
+    const raw = await readRawStdin();
+    const out = await runHook(raw);
+    process.stdout.write(JSON.stringify(out));
     return 0;
   }
   process.stdout.write(help());

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "$comment": "The PreToolUse/Bash hook, declared in the plugin so it registers automatically at user/global scope when the plugin is installed — no mutation of the user's project .claude/settings.json, and it follows the user across every repo and git worktree. The command runs the plugin's BUNDLED, self-contained bin via ${CLAUDE_PLUGIN_ROOT} (dist-bundle/add-reasoning-to-prs.js — committed to git, since Claude Code runs no build step on install), NOT `npx`, which would resolve a possibly-stale or absent global install.",
+  "$comment_behavior": "SYNCHRONOUS (Claude Code reads this command's STDOUT for the decision) and FAIL-OPEN: when the Bash command is a `git commit` on the default branch or a `gh pr create` that lacks a why-block, the bin denies with a reason + injected guidance so the live model composes the block and re-runs; every other command — and every error — yields an empty `{}` and exit 0, so the git op always proceeds. It never exits 2 and never hard-blocks.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/dist-bundle/add-reasoning-to-prs.js\" hook"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,10 +4,12 @@
 // calling `run()` directly. The thin bin entrypoint (bin/add-reasoning-to-prs.ts) maps
 // its return value to a process exit code.
 //
-// v1 (scaffold) handles only --version / --help. Later work adds the `hook` subcommand
-// (the PreToolUse handler Claude Code invokes) and `install`.
+// Handles --version / --help and the `hook` subcommand (the PreToolUse handler Claude
+// Code invokes). `install` lands later.
 
 import { VERSION } from './version.js';
+import { readRawStdin } from './stdin.js';
+import { runHook } from './hook.js';
 
 export function help(): string {
   return `add-reasoning-to-prs ${VERSION}
@@ -36,6 +38,16 @@ export async function run(argv: string[]): Promise<number> {
 
   if (cmd === '--version' || cmd === '-v' || cmd === 'version') {
     process.stdout.write(VERSION + '\n');
+    return 0;
+  }
+
+  // The PreToolUse hook entrypoint: read the payload off stdin, print the decision JSON,
+  // and ALWAYS exit 0. runHook never throws (any error → `{}` = no injection), so this
+  // path can never block the user's git op.
+  if (cmd === 'hook') {
+    const raw = await readRawStdin();
+    const out = await runHook(raw);
+    process.stdout.write(JSON.stringify(out));
     return 0;
   }
 

--- a/src/command.test.ts
+++ b/src/command.test.ts
@@ -1,0 +1,46 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyCommand } from './command.js';
+
+test('detects plain git commit forms', () => {
+  assert.equal(classifyCommand('git commit'), 'git-commit');
+  assert.equal(classifyCommand('git commit -m "add feature"'), 'git-commit');
+  assert.equal(classifyCommand('git commit -am "wip"'), 'git-commit');
+  assert.equal(classifyCommand('git commit --amend --no-edit'), 'git-commit');
+});
+
+test('detects git commit through global options and their values', () => {
+  assert.equal(classifyCommand('git -C /some/path commit -m x'), 'git-commit');
+  assert.equal(classifyCommand('git -c user.email=a@b.co commit -m x'), 'git-commit');
+  assert.equal(classifyCommand('git --git-dir=/r/.git commit'), 'git-commit');
+});
+
+test('detects git commit with env prefixes, path prefixes, and in a chain', () => {
+  assert.equal(classifyCommand('GIT_AUTHOR_NAME=me git commit -m x'), 'git-commit');
+  assert.equal(classifyCommand('/usr/bin/git commit -m x'), 'git-commit');
+  assert.equal(classifyCommand('cd repo && git commit -m x'), 'git-commit');
+  assert.equal(classifyCommand('git add -A && git commit -m x'), 'git-commit');
+});
+
+test('detects gh pr create', () => {
+  assert.equal(classifyCommand('gh pr create'), 'gh-pr-create');
+  assert.equal(classifyCommand('gh pr create --title "T" --body "B"'), 'gh-pr-create');
+  assert.equal(classifyCommand('gh pr create --fill && echo done'), 'gh-pr-create');
+});
+
+test('does NOT match look-alikes', () => {
+  assert.equal(classifyCommand('git push'), 'other');
+  assert.equal(classifyCommand('git log --grep commit'), 'other');
+  assert.equal(classifyCommand('git commitfoo'), 'other');
+  assert.equal(classifyCommand('gh pr list'), 'other');
+  assert.equal(classifyCommand('gh pr view 12'), 'other');
+  assert.equal(classifyCommand('echo git commit'), 'other');
+  assert.equal(classifyCommand('cat commit.txt'), 'other');
+});
+
+test('handles empty / junk input safely', () => {
+  assert.equal(classifyCommand(''), 'other');
+  assert.equal(classifyCommand('   '), 'other');
+  // @ts-expect-error — defensive: non-string input must not throw.
+  assert.equal(classifyCommand(undefined), 'other');
+});

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,0 +1,73 @@
+// command.ts — classify a Bash `tool_input.command` string.
+//
+// The PreToolUse matcher only matches the TOOL NAME (Bash), so the hook itself has to
+// look inside the command string to decide whether it's a `git commit` or a
+// `gh pr create` — the two moments we want a "why" block. This is intentionally a
+// lightweight classifier, not a shell parser: it splits on the common control operators
+// and inspects each simple-command segment. Anything it can't confidently classify is
+// `other` (→ the hook does nothing), so a false "other" is always the safe direction.
+
+import { basename } from 'node:path';
+
+export type CommandKind = 'git-commit' | 'gh-pr-create' | 'other';
+
+// Split a command line into simple-command segments on shell control operators
+// (`&&`, `||`, `;`, `|`, `&`, newline). Good enough to isolate the invocation we care
+// about from surrounding `cd …`, pipes, and chains.
+const SEGMENT_SPLIT = /&&|\|\||[;\n|&]/;
+
+// git "global" options (before the subcommand) that consume the FOLLOWING token as their
+// value — so we skip that value when scanning for the subcommand (e.g. `git -C path commit`).
+const GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
+  '-C',
+  '-c',
+  '--git-dir',
+  '--work-tree',
+  '--namespace',
+  '--exec-path',
+]);
+
+/** Classify a full command line by its first recognizable git/gh invocation. */
+export function classifyCommand(command: string): CommandKind {
+  if (typeof command !== 'string' || command.trim().length === 0) return 'other';
+  for (const segment of command.split(SEGMENT_SPLIT)) {
+    const kind = classifySegment(segment);
+    if (kind !== 'other') return kind;
+  }
+  return 'other';
+}
+
+function classifySegment(segment: string): CommandKind {
+  const tokens = segment.trim().split(/\s+/).filter(Boolean);
+  let i = 0;
+  // Skip leading `VAR=value` env assignments and a bare `env` wrapper.
+  while (i < tokens.length && (/^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i]) || tokens[i] === 'env')) {
+    i++;
+  }
+  if (i >= tokens.length) return 'other';
+
+  const prog = basename(tokens[i]);
+
+  if (prog === 'git') {
+    // Find the subcommand: the first non-option token after `git`, skipping global
+    // options and any value they consume.
+    for (let j = i + 1; j < tokens.length; j++) {
+      const t = tokens[j];
+      if (t.startsWith('-')) {
+        if (GIT_GLOBAL_OPTS_WITH_VALUE.has(t)) j++; // its value is the next token — skip it
+        continue;
+      }
+      return t === 'commit' ? 'git-commit' : 'other';
+    }
+    return 'other';
+  }
+
+  if (prog === 'gh') {
+    // `gh pr create` — the first two non-option words after `gh` must be `pr` then
+    // `create` (flags may follow). Options before the subcommand are uncommon for gh.
+    const words = tokens.slice(i + 1).filter((t) => !t.startsWith('-'));
+    return words[0] === 'pr' && words[1] === 'create' ? 'gh-pr-create' : 'other';
+  }
+
+  return 'other';
+}

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,0 +1,52 @@
+// git.ts — minimal, fail-safe git queries via the git CLI.
+//
+// The hook needs to know whether a `git commit` is landing on the repo's DEFAULT branch
+// (the direct-push surface) or a feature branch (which defers to PR-create). Every helper
+// returns a benign default (null / false) on any error — a missing git, a non-repo cwd, a
+// timeout — so the hook stays fail-open and never blocks the user's git op.
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const pexec = promisify(execFile);
+
+/** Run a git command in `cwd`, returning trimmed stdout or null on any failure. */
+async function git(args: string[], cwd: string): Promise<string | null> {
+  try {
+    const { stdout } = await pexec('git', args, { cwd, timeout: 3000, windowsHide: true });
+    return stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
+/** The current branch name (e.g. "main"), or null in a detached HEAD / non-repo / error. */
+export async function currentBranch(cwd: string): Promise<string | null> {
+  return git(['symbolic-ref', '--quiet', '--short', 'HEAD'], cwd);
+}
+
+/**
+ * The repo's default branch name, best-effort and OFFLINE:
+ *   1. the local `origin/HEAD` symbolic ref (set by clone / `git remote set-head`), else
+ *   2. null — the caller falls back to a common-name heuristic.
+ * We deliberately avoid `git remote show origin` (a network round-trip) to keep the hook
+ * fast and offline-safe.
+ */
+export async function defaultBranch(cwd: string): Promise<string | null> {
+  const head = await git(['symbolic-ref', '--quiet', '--short', 'refs/remotes/origin/HEAD'], cwd);
+  if (head) return head.replace(/^origin\//, '');
+  return null;
+}
+
+/**
+ * True if the current branch is the repo's default branch. When the remote default is
+ * unknown (no origin/HEAD), fall back to the conventional names — a direct commit onto
+ * `main`/`master` is the case we care about. Any error → false (defer / do nothing).
+ */
+export async function isDefaultBranch(cwd: string): Promise<boolean> {
+  const current = await currentBranch(cwd);
+  if (!current) return false;
+  const def = await defaultBranch(cwd);
+  if (def) return current === def;
+  return current === 'main' || current === 'master';
+}

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -1,0 +1,73 @@
+// guidance.ts — the instruction ("template + guardrails") the hook injects when it denies
+// a commit / PR-create that lacks a why-block.
+//
+// This text is what the LIVE model reads on the denial and acts on: it composes the
+// forward-only block from the session's real deliberation and re-runs the command. The
+// hook itself never authors the block — it only asks for it. The guidance is surface-
+// aware (PR body vs commit message use different delimiters).
+
+import {
+  PR_MARKER_OPEN,
+  PR_MARKER_CLOSE,
+  COMMIT_MARKER_OPEN,
+  COMMIT_MARKER_CLOSE,
+} from './marker.js';
+
+export type Surface = 'pr' | 'commit';
+
+interface SurfaceCopy {
+  open: string;
+  close: string;
+  moment: string;
+  where: string;
+}
+
+function surfaceCopy(surface: Surface): SurfaceCopy {
+  if (surface === 'pr') {
+    return {
+      open: PR_MARKER_OPEN,
+      close: PR_MARKER_CLOSE,
+      moment: 'this pull request is opened',
+      where: 'the pull request description (the --body / --body-file text)',
+    };
+  }
+  return {
+    open: COMMIT_MARKER_OPEN,
+    close: COMMIT_MARKER_CLOSE,
+    moment: 'this commit lands on the default branch',
+    where: 'the commit message body',
+  };
+}
+
+/**
+ * Build the guidance for a surface. The SAME text is used for both the
+ * `permissionDecisionReason` (the reliable floor, honored on every Claude Code version)
+ * and `additionalContext` (a progressive enhancement), so the model always sees it.
+ */
+export function buildGuidance(surface: Surface): string {
+  const c = surfaceCopy(surface);
+  return `add-reasoning-to-prs: before ${c.moment}, add a short, forward-only "why" block to ${c.where}, then re-run the command.
+
+Compose the block ONLY from what you actually decided in THIS session — never invent. Include only the sections that genuinely apply, and drop any that don't:
+
+- Decisions — the choices you made and why (not what changed; the diff already shows that).
+- Assumptions — what you took as given that a reviewer should confirm.
+- Trade-offs — what you knowingly gave up, and the alternative you rejected.
+- Limitations — known gaps, risks, or follow-ups you're deliberately deferring.
+
+Rules:
+- Forward-only: capture what the diff can't show — the why, and the risks knowingly taken. Never summarize the changes.
+- Grounded: every line must trace to real deliberation in this session. Cut anything padded, generic, or inferred.
+- If the session had no genuine decisions to record, that's fine — leave it out rather than manufacture filler.
+- Keep it tight: a few lines per section at most.
+- Wrap the block EXACTLY between these two markers so it is detected and left untouched on later runs:
+
+${c.open}
+Decisions:
+- <one concise line per decision>
+Trade-offs:
+- <...>
+${c.close}
+
+Then re-run your original command with the block included in ${c.where}.`;
+}

--- a/src/hook.test.ts
+++ b/src/hook.test.ts
@@ -1,0 +1,78 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { runHook } from './hook.js';
+import { PR_MARKER_OPEN, PR_MARKER_CLOSE } from './marker.js';
+
+/** Build a PreToolUse/Bash payload string. */
+function payload(command: string, extra: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    hook_event_name: 'PreToolUse',
+    tool_name: 'Bash',
+    tool_input: { command },
+    cwd: '/tmp/repo',
+    session_id: 's1',
+    ...extra,
+  });
+}
+
+const onDefault = { isDefaultBranchImpl: async () => true };
+const onFeature = { isDefaultBranchImpl: async () => false };
+
+test('gh pr create without a block → deny with guidance (both channels)', async () => {
+  const out = await runHook(payload('gh pr create --title T --body B'), onFeature);
+  const hs = out.hookSpecificOutput;
+  assert.ok(hs, 'expected a hookSpecificOutput');
+  assert.equal(hs.hookEventName, 'PreToolUse');
+  assert.equal(hs.permissionDecision, 'deny');
+  assert.match(hs.permissionDecisionReason, /forward-only/i);
+  assert.match(hs.permissionDecisionReason, /pull request description/i);
+  // The reason (reliable floor) and additionalContext (progressive enhancement) both
+  // carry the guidance, so the model sees it regardless of version support.
+  assert.equal(hs.additionalContext, hs.permissionDecisionReason);
+});
+
+test('gh pr create that ALREADY has the block → no-op (idempotent)', async () => {
+  const cmd = `gh pr create --body "Body ${PR_MARKER_OPEN} Decisions: x ${PR_MARKER_CLOSE}"`;
+  const out = await runHook(payload(cmd), onFeature);
+  assert.deepEqual(out, {});
+});
+
+test('git commit on the DEFAULT branch → deny with the commit-surface guidance', async () => {
+  const out = await runHook(payload('git commit -m "wip"'), onDefault);
+  const hs = out.hookSpecificOutput;
+  assert.ok(hs);
+  assert.equal(hs.permissionDecision, 'deny');
+  assert.match(hs.permissionDecisionReason, /commit message body/i);
+});
+
+test('git commit on a FEATURE branch → no-op (defers to PR-create)', async () => {
+  const out = await runHook(payload('git commit -m "wip"'), onFeature);
+  assert.deepEqual(out, {});
+});
+
+test('non-matching command → no-op', async () => {
+  assert.deepEqual(await runHook(payload('git push'), onDefault), {});
+  assert.deepEqual(await runHook(payload('ls -la'), onDefault), {});
+});
+
+test('non-Bash tool → no-op', async () => {
+  const raw = JSON.stringify({ tool_name: 'Read', tool_input: { file_path: '/x' } });
+  assert.deepEqual(await runHook(raw, onDefault), {});
+});
+
+test('fail-open on bad / empty / missing input', async () => {
+  assert.deepEqual(await runHook('not json', onDefault), {});
+  assert.deepEqual(await runHook('', onDefault), {});
+  assert.deepEqual(await runHook('null', onDefault), {});
+  assert.deepEqual(await runHook(JSON.stringify({ tool_name: 'Bash', tool_input: {} }), onDefault), {});
+});
+
+test('fail-open when the branch check throws (git commit) → no-op, never a throw', async () => {
+  const throwing = {
+    isDefaultBranchImpl: async () => {
+      throw new Error('git blew up');
+    },
+  };
+  const out = await runHook(payload('git commit -m x'), throwing);
+  assert.deepEqual(out, {});
+});

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -1,0 +1,95 @@
+// hook.ts — the PreToolUse/Bash hook orchestrator.
+//
+// Claude Code runs this synchronously BEFORE a Bash tool call and reads its stdout for a
+// decision. When the command is a `git commit` (on the default branch) or a `gh pr create`
+// that lacks a why-block, we DENY with a reason + injected guidance, so the live model
+// composes the block and re-runs the command. Everything else → an empty `{}` (no
+// injection, the tool proceeds).
+//
+// NON-NEGOTIABLE POSTURE (fail-open): this must NEVER block or delay the user's git op.
+// Every failure mode — unparseable payload, missing git, a throw anywhere — resolves to
+// `{}` and exit 0. It never exits 2, never hard-blocks.
+
+import { classifyCommand } from './command.js';
+import { hasMarker } from './marker.js';
+import { isDefaultBranch } from './git.js';
+import { buildGuidance, type Surface } from './guidance.js';
+
+/** The PreToolUse hook output. `{}` = no injection (fail-open); otherwise a deny. */
+export interface PreToolUseHookOutput {
+  hookSpecificOutput?: {
+    hookEventName: 'PreToolUse';
+    permissionDecision: 'deny';
+    permissionDecisionReason: string;
+    additionalContext: string;
+  };
+}
+
+export interface HookDeps {
+  /** Fallback cwd when the payload omits one. Defaults to process.cwd(). */
+  cwd?: string;
+  /** Test seam: the default-branch check. Defaults to git.isDefaultBranch. */
+  isDefaultBranchImpl?: (cwd: string) => Promise<boolean>;
+}
+
+/**
+ * Build the PreToolUse hook output for a raw stdin payload. NEVER throws — any problem
+ * yields `{}` (no injection; the git op proceeds).
+ */
+export async function runHook(rawStdin: string, deps: HookDeps = {}): Promise<PreToolUseHookOutput> {
+  try {
+    let payload: unknown;
+    try {
+      payload = JSON.parse(rawStdin);
+    } catch {
+      return {}; // unparseable payload → no injection
+    }
+    const rec = (payload && typeof payload === 'object' ? payload : {}) as Record<string, unknown>;
+
+    // Only act on the Bash tool (the matcher already scopes this, but be defensive).
+    if (rec.tool_name !== undefined && rec.tool_name !== 'Bash') return {};
+
+    const toolInput = rec.tool_input;
+    const command =
+      toolInput && typeof toolInput === 'object'
+        ? (toolInput as Record<string, unknown>).command
+        : undefined;
+    if (typeof command !== 'string' || command.trim().length === 0) return {};
+
+    const kind = classifyCommand(command);
+    if (kind === 'other') return {};
+
+    // Idempotency: the command already carries a block (the model's own retry, or a
+    // hand-written one) → leave it alone, so a re-run is a no-op and we never re-deny.
+    if (hasMarker(command)) return {};
+
+    const cwd = typeof rec.cwd === 'string' && rec.cwd ? rec.cwd : (deps.cwd ?? process.cwd());
+
+    // Surface routing: `gh pr create` → the PR body. A `git commit` only gets a block on
+    // the DEFAULT branch (the direct-push surface); a feature-branch commit defers to
+    // PR-create and is left alone here.
+    let surface: Surface;
+    if (kind === 'gh-pr-create') {
+      surface = 'pr';
+    } else {
+      const onDefault = await (deps.isDefaultBranchImpl ?? isDefaultBranch)(cwd).catch(() => false);
+      if (!onDefault) return {};
+      surface = 'commit';
+    }
+
+    const guidance = buildGuidance(surface);
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: guidance,
+        // Progressive enhancement. Claude Code exposes no version signal to hooks, so we
+        // always emit additionalContext too: newer versions surface it, older ones ignore
+        // the unknown field, and the reason above carries the guidance either way.
+        additionalContext: guidance,
+      },
+    };
+  } catch {
+    return {}; // belt-and-braces: any failure → no injection, the git op proceeds
+  }
+}

--- a/src/marker.test.ts
+++ b/src/marker.test.ts
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  hasMarker,
+  PR_MARKER_OPEN,
+  PR_MARKER_CLOSE,
+  COMMIT_MARKER_OPEN,
+  COMMIT_MARKER_CLOSE,
+  MARKER_TOKEN,
+} from './marker.js';
+
+test('every delimiter (both surfaces, open + close) is detected by hasMarker', () => {
+  for (const m of [PR_MARKER_OPEN, PR_MARKER_CLOSE, COMMIT_MARKER_OPEN, COMMIT_MARKER_CLOSE]) {
+    assert.equal(hasMarker(m), true, `expected hasMarker(${JSON.stringify(m)}) === true`);
+    assert.ok(m.includes(MARKER_TOKEN), `expected ${JSON.stringify(m)} to embed the token`);
+  }
+});
+
+test('detects a marker embedded in a larger body', () => {
+  const body = `Add the widget.\n\n${PR_MARKER_OPEN}\nDecisions:\n- did a thing\n${PR_MARKER_CLOSE}\n`;
+  assert.equal(hasMarker(body), true);
+});
+
+test('returns false for text without a marker and for empty/nullish input', () => {
+  assert.equal(hasMarker('just a normal PR body'), false);
+  assert.equal(hasMarker(''), false);
+  assert.equal(hasMarker(undefined), false);
+  assert.equal(hasMarker(null), false);
+});

--- a/src/marker.ts
+++ b/src/marker.ts
@@ -1,0 +1,34 @@
+// marker.ts — the machine-readable delimiter that wraps the "why" block.
+//
+// SINGLE SOURCE OF TRUTH for the marker token. Two consumers must agree on it exactly:
+//   1. This hook — to detect a block that's already present (idempotency / skip
+//      re-injection) and to tell the model which delimiter to emit.
+//   2. The ingestion side that reads git prose — so it can recognize and SKIP this
+//      hook's own block instead of re-ingesting it as an independent decision.
+// Anyone changing the token must change it in both places.
+//
+// The token is deliberately surface-appropriate:
+//   • PR body is markdown, so an HTML comment renders invisibly.
+//   • A commit message shows HTML comments as literal text, so it uses a plain sentinel.
+// Both forms embed the same stable substring (MARKER_TOKEN) so one check finds either.
+
+/** The stable substring present in every marker (open or close, either surface). */
+export const MARKER_TOKEN = 'backthread:why';
+
+/** PR-body (markdown) delimiters — HTML comments, invisible when rendered. */
+export const PR_MARKER_OPEN = '<!-- backthread:why -->';
+export const PR_MARKER_CLOSE = '<!-- /backthread:why -->';
+
+/** Commit-message delimiters — a plain sentinel (HTML comments don't hide in git log). */
+export const COMMIT_MARKER_OPEN = '--- backthread:why ---';
+export const COMMIT_MARKER_CLOSE = '--- backthread:why end ---';
+
+/**
+ * True if the given text already carries a why-block marker (either surface). Used for
+ * idempotency — a command that already contains the block is left alone, so a re-run is
+ * a no-op and the model's own retry (with the block added) is never re-denied.
+ */
+export function hasMarker(text: string | undefined | null): boolean {
+  if (typeof text !== 'string' || text.length === 0) return false;
+  return text.includes(MARKER_TOKEN);
+}

--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -1,0 +1,22 @@
+// stdin.ts — read the raw hook payload from stdin.
+//
+// Claude Code feeds the PreToolUse payload on STDIN as JSON. We also accept an
+// ADD_REASONING_TO_PRS_HOOK_INPUT env var as a test/dev fallback. A TTY (no piped input)
+// resolves to '' rather than hanging, and any read error degrades to whatever was read so
+// far — never throws (the parse layer then yields no injection).
+
+export async function readRawStdin(
+  env: NodeJS.ProcessEnv = process.env,
+  stdin: NodeJS.ReadStream = process.stdin,
+): Promise<string> {
+  const fromEnv = env.ADD_REASONING_TO_PRS_HOOK_INPUT;
+  if (fromEnv && fromEnv.trim().length > 0) return fromEnv;
+  if (stdin.isTTY) return '';
+  return new Promise<string>((resolve) => {
+    let data = '';
+    stdin.setEncoding('utf8');
+    stdin.on('data', (chunk) => (data += chunk));
+    stdin.on('end', () => resolve(data));
+    stdin.on('error', () => resolve(data));
+  });
+}


### PR DESCRIPTION
## PreToolUse/Bash hook harness + why-block injection

The core mechanism. A `PreToolUse` hook (matcher `Bash`) inspects the about-to-run command and, when it's a `git commit` on the default branch or a `gh pr create` that **lacks** a why-block, **denies** the tool call with a reason and **injects** surface-aware guidance — so the live model composes the forward-only block and re-runs the command itself. The hook never authors the block; it only asks for it.

### Pieces
- **`command.ts`** — a lightweight classifier (`git-commit` / `gh-pr-create` / `other`). Not a shell parser: it splits on control operators (`&&`, `||`, `;`, `|`, `&`) and inspects each segment, tolerating git global options (`-C`, `-c value`, …), `VAR=…`/path prefixes, and command chains. Anything ambiguous → `other` (do nothing) — the safe direction.
- **`git.ts`** — fail-safe, **offline** default-branch detection (local `origin/HEAD`, falling back to `main`/`master`). Any error → `false` (defer).
- **`marker.ts`** — the single source of truth for the delimiter token (`backthread:why`), with surface-appropriate forms: an **HTML comment** in a PR body (renders invisibly) and a **plain sentinel** in a commit message. The token is also what the ingestion side keys its self-ingestion skip on.
- **`guidance.ts`** — the injected "template + guardrails": the four forward-only primitives (Decisions / Assumptions / Trade-offs / Limitations), the *why-not-what* and *grounded / leave-empty* rules, and the exact delimiter to wrap the block in — surface-aware.
- **`hook.ts`** — the orchestrator. Emits the current Claude Code deny schema (`hookSpecificOutput.permissionDecision: "deny"` + `permissionDecisionReason`), and puts the guidance in **both** the reason (the reliable floor, honored on every version) **and** `additionalContext` (a progressive enhancement — Claude Code exposes no version signal to hooks, so we always emit both; older versions ignore the unknown field). **Fail-open:** any error → `{}` + exit 0; it never exits 2 and never hard-blocks.
- **`hooks/hooks.json`** — plugin registration that runs the committed self-contained bundle via `${CLAUDE_PLUGIN_ROOT}`.

### Scope boundaries (deliberately deferred)
- The full 4-primitive template formalization + deeper idempotency (reading a `--body-file`/`-F` file to detect an existing block) → template/delimiter follow-up.
- The per-repo off-switch, per-invocation skip, and the anti-loop **deny cap** → the surface-routing + trigger-controls follow-up.

### Done when
- A matching command without a block → **denies with the template** — verified for `gh pr create` and for `git commit` on the default branch (through the built bundle, against a real scratch repo).
- Any error → **no-op** — verified: unparseable/empty/missing payload, non-Bash tool, non-matching command, and a throwing branch check all return `{}` + exit 0.

### Testing
- `npm run typecheck` — clean. `npm test` — 23/23 pass, bundle rebuilt + in sync.
- End-to-end through `dist-bundle/add-reasoning-to-prs.js hook`: `gh pr create` (no marker) → deny with PR-body guidance; same with a marker present → `{}`; `git push` → `{}`; garbage stdin → `{}` (exit 0); real scratch repo → `git commit` on `main` denies, on a feature branch is a no-op.
