### PR TITLE
Why-block template + delimiter + file-based idempotency

### DIFF
--- a/dist-bundle/add-reasoning-to-prs.js
+++ b/dist-bundle/add-reasoning-to-prs.js
@@ -8,12 +8,12 @@ async function readRawStdin(env = process.env, stdin = process.stdin) {
   const fromEnv = env.ADD_REASONING_TO_PRS_HOOK_INPUT;
   if (fromEnv && fromEnv.trim().length > 0) return fromEnv;
   if (stdin.isTTY) return "";
-  return new Promise((resolve) => {
+  return new Promise((resolve2) => {
     let data = "";
     stdin.setEncoding("utf8");
     stdin.on("data", (chunk) => data += chunk);
-    stdin.on("end", () => resolve(data));
-    stdin.on("error", () => resolve(data));
+    stdin.on("end", () => resolve2(data));
+    stdin.on("error", () => resolve2(data));
   });
 }
 
@@ -101,22 +101,81 @@ async function isDefaultBranch(cwd) {
   return current === "main" || current === "master";
 }
 
+// src/bodyFile.ts
+import { readFile, stat } from "node:fs/promises";
+import { isAbsolute, resolve } from "node:path";
+var FILE_FLAGS = /* @__PURE__ */ new Set(["--body-file", "--file", "-F"]);
+var MAX_BODY_FILE_BYTES = 1e6;
+function unquote(s) {
+  const t = s.trim();
+  if (t.length >= 2 && (t[0] === '"' && t[t.length - 1] === '"' || t[0] === "'" && t[t.length - 1] === "'")) {
+    return t.slice(1, -1);
+  }
+  return t;
+}
+function extractBodyFilePath(command) {
+  if (typeof command !== "string") return null;
+  const tokens = command.split(/\s+/).filter(Boolean);
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i];
+    const eq = t.indexOf("=");
+    if (eq > 0) {
+      if (FILE_FLAGS.has(t.slice(0, eq))) {
+        const val = unquote(t.slice(eq + 1));
+        return val && val !== "-" ? val : null;
+      }
+      continue;
+    }
+    if (FILE_FLAGS.has(t)) {
+      const val = unquote(tokens[i + 1] ?? "");
+      return val && val !== "-" ? val : null;
+    }
+  }
+  return null;
+}
+async function readBodyFile(path, cwd) {
+  try {
+    const full = isAbsolute(path) ? path : resolve(cwd, path);
+    const s = await stat(full);
+    if (!s.isFile() || s.size > MAX_BODY_FILE_BYTES) return "";
+    return await readFile(full, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+// src/template.ts
+var PRIMITIVES = ["decisions", "assumptions", "tradeoffs", "limitations"];
+var HEADINGS = {
+  decisions: "Decisions",
+  assumptions: "Assumptions",
+  tradeoffs: "Trade-offs",
+  limitations: "Limitations"
+};
+function delimiters(surface) {
+  return surface === "pr" ? { open: PR_MARKER_OPEN, close: PR_MARKER_CLOSE } : { open: COMMIT_MARKER_OPEN, close: COMMIT_MARKER_CLOSE };
+}
+
 // src/guidance.ts
 function surfaceCopy(surface) {
-  if (surface === "pr") {
-    return {
-      open: PR_MARKER_OPEN,
-      close: PR_MARKER_CLOSE,
-      moment: "this pull request is opened",
-      where: "the pull request description (the --body / --body-file text)"
-    };
-  }
-  return {
-    open: COMMIT_MARKER_OPEN,
-    close: COMMIT_MARKER_CLOSE,
+  return surface === "pr" ? {
+    moment: "this pull request is opened",
+    where: "the pull request description (the --body / --body-file text)"
+  } : {
     moment: "this commit lands on the default branch",
     where: "the commit message body"
   };
+}
+function exampleBlock(surface) {
+  const { open, close } = delimiters(surface);
+  const isPr = surface === "pr";
+  const lines = [open];
+  for (const key of PRIMITIVES) {
+    lines.push(isPr ? `**${HEADINGS[key]}**` : `${HEADINGS[key]}:`);
+    lines.push("- <one concise line \u2014 omit this whole section if it does not apply>");
+  }
+  lines.push(close);
+  return lines.join("\n");
 }
 function buildGuidance(surface) {
   const c = surfaceCopy(surface);
@@ -134,14 +193,9 @@ Rules:
 - Grounded: every line must trace to real deliberation in this session. Cut anything padded, generic, or inferred.
 - If the session had no genuine decisions to record, that's fine \u2014 leave it out rather than manufacture filler.
 - Keep it tight: a few lines per section at most.
-- Wrap the block EXACTLY between these two markers so it is detected and left untouched on later runs:
+- Wrap the block EXACTLY between the two markers below so it is detected and left untouched on later runs:
 
-${c.open}
-Decisions:
-- <one concise line per decision>
-Trade-offs:
-- <...>
-${c.close}
+${exampleBlock(surface)}
 
 Then re-run your original command with the block included in ${c.where}.`;
 }
@@ -162,8 +216,13 @@ async function runHook(rawStdin, deps = {}) {
     if (typeof command !== "string" || command.trim().length === 0) return {};
     const kind = classifyCommand(command);
     if (kind === "other") return {};
-    if (hasMarker(command)) return {};
     const cwd = typeof rec.cwd === "string" && rec.cwd ? rec.cwd : deps.cwd ?? process.cwd();
+    if (hasMarker(command)) return {};
+    const bodyFilePath = extractBodyFilePath(command);
+    if (bodyFilePath) {
+      const contents = await readBodyFile(bodyFilePath, cwd);
+      if (hasMarker(contents)) return {};
+    }
     let surface;
     if (kind === "gh-pr-create") {
       surface = "pr";

--- a/dist-bundle/add-reasoning-to-prs.js
+++ b/dist-bundle/add-reasoning-to-prs.js
@@ -106,28 +106,48 @@ import { readFile, stat } from "node:fs/promises";
 import { isAbsolute, resolve } from "node:path";
 var FILE_FLAGS = /* @__PURE__ */ new Set(["--body-file", "--file", "-F"]);
 var MAX_BODY_FILE_BYTES = 1e6;
-function unquote(s) {
-  const t = s.trim();
-  if (t.length >= 2 && (t[0] === '"' && t[t.length - 1] === '"' || t[0] === "'" && t[t.length - 1] === "'")) {
-    return t.slice(1, -1);
+function shellSplit(command) {
+  const tokens = [];
+  let cur = "";
+  let quote = null;
+  let started = false;
+  for (const ch of command) {
+    if (quote) {
+      if (ch === quote) quote = null;
+      else cur += ch;
+      started = true;
+    } else if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+    } else if (/\s/.test(ch)) {
+      if (started) {
+        tokens.push(cur);
+        cur = "";
+        started = false;
+      }
+    } else {
+      cur += ch;
+      started = true;
+    }
   }
-  return t;
+  if (started) tokens.push(cur);
+  return tokens;
 }
 function extractBodyFilePath(command) {
   if (typeof command !== "string") return null;
-  const tokens = command.split(/\s+/).filter(Boolean);
+  const tokens = shellSplit(command);
   for (let i = 0; i < tokens.length; i++) {
     const t = tokens[i];
     const eq = t.indexOf("=");
-    if (eq > 0) {
+    if (eq > 0 && t.startsWith("-")) {
       if (FILE_FLAGS.has(t.slice(0, eq))) {
-        const val = unquote(t.slice(eq + 1));
+        const val = t.slice(eq + 1);
         return val && val !== "-" ? val : null;
       }
       continue;
     }
     if (FILE_FLAGS.has(t)) {
-      const val = unquote(tokens[i + 1] ?? "");
+      const val = tokens[i + 1] ?? "";
       return val && val !== "-" ? val : null;
     }
   }

--- a/dist-bundle/add-reasoning-to-prs.js
+++ b/dist-bundle/add-reasoning-to-prs.js
@@ -155,6 +155,29 @@ var HEADINGS = {
 function delimiters(surface) {
   return surface === "pr" ? { open: PR_MARKER_OPEN, close: PR_MARKER_CLOSE } : { open: COMMIT_MARKER_OPEN, close: COMMIT_MARKER_CLOSE };
 }
+function clean(items) {
+  if (!Array.isArray(items)) return [];
+  return items.map((s) => typeof s === "string" ? s.trim() : "").filter(Boolean);
+}
+function isEmptyBlock(p) {
+  return PRIMITIVES.every((k) => clean(p[k]).length === 0);
+}
+function renderBlock(surface, p) {
+  if (isEmptyBlock(p)) return "";
+  const { open, close } = delimiters(surface);
+  const isPr = surface === "pr";
+  const lines = [open];
+  for (const key of PRIMITIVES) {
+    const items = clean(p[key]);
+    if (items.length === 0) continue;
+    lines.push(isPr ? `**${HEADINGS[key]}**` : `${HEADINGS[key]}:`);
+    for (const item of items) lines.push(`- ${item}`);
+    if (isPr) lines.push("");
+  }
+  while (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+  lines.push(close);
+  return lines.join("\n");
+}
 
 // src/guidance.ts
 function surfaceCopy(surface) {
@@ -167,15 +190,13 @@ function surfaceCopy(surface) {
   };
 }
 function exampleBlock(surface) {
-  const { open, close } = delimiters(surface);
-  const isPr = surface === "pr";
-  const lines = [open];
-  for (const key of PRIMITIVES) {
-    lines.push(isPr ? `**${HEADINGS[key]}**` : `${HEADINGS[key]}:`);
-    lines.push("- <one concise line \u2014 omit this whole section if it does not apply>");
-  }
-  lines.push(close);
-  return lines.join("\n");
+  const placeholder = ["<one concise line \u2014 omit this whole section if it does not apply>"];
+  return renderBlock(surface, {
+    decisions: placeholder,
+    assumptions: placeholder,
+    tradeoffs: placeholder,
+    limitations: placeholder
+  });
 }
 function buildGuidance(surface) {
   const c = surfaceCopy(surface);

--- a/src/bodyFile.test.ts
+++ b/src/bodyFile.test.ts
@@ -1,0 +1,33 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { extractBodyFilePath, readBodyFile } from './bodyFile.js';
+import { PR_MARKER_OPEN } from './marker.js';
+
+test('extracts a body/message file path across the flag forms', () => {
+  assert.equal(extractBodyFilePath('gh pr create --body-file notes.md'), 'notes.md');
+  assert.equal(extractBodyFilePath('gh pr create --body-file=notes.md'), 'notes.md');
+  assert.equal(extractBodyFilePath('gh pr create -F notes.md'), 'notes.md');
+  assert.equal(extractBodyFilePath('git commit -F msg.txt'), 'msg.txt');
+  assert.equal(extractBodyFilePath('git commit --file msg.txt'), 'msg.txt');
+  assert.equal(extractBodyFilePath('git commit --file=msg.txt'), 'msg.txt');
+  assert.equal(extractBodyFilePath("gh pr create --body-file 'notes.md'"), 'notes.md');
+});
+
+test('returns null when there is no file (inline body, or stdin "-")', () => {
+  assert.equal(extractBodyFilePath('gh pr create --body "inline"'), null);
+  assert.equal(extractBodyFilePath('git commit -m "inline"'), null);
+  assert.equal(extractBodyFilePath('git commit -F -'), null);
+  assert.equal(extractBodyFilePath(''), null);
+});
+
+test('readBodyFile reads contents, and degrades to "" on a missing file', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'arp-body-'));
+  const file = join(dir, 'notes.md');
+  await writeFile(file, `Body\n${PR_MARKER_OPEN}\nDecisions:\n- x\n`, 'utf8');
+  const contents = await readBodyFile('notes.md', dir);
+  assert.match(contents, /backthread:why/);
+  assert.equal(await readBodyFile('does-not-exist.md', dir), '');
+});

--- a/src/bodyFile.test.ts
+++ b/src/bodyFile.test.ts
@@ -14,6 +14,13 @@ test('extracts a body/message file path across the flag forms', () => {
   assert.equal(extractBodyFilePath('git commit --file msg.txt'), 'msg.txt');
   assert.equal(extractBodyFilePath('git commit --file=msg.txt'), 'msg.txt');
   assert.equal(extractBodyFilePath("gh pr create --body-file 'notes.md'"), 'notes.md');
+  // Quoted path containing spaces survives as one token (both flag forms).
+  assert.equal(extractBodyFilePath('gh pr create --body-file "my notes.md"'), 'my notes.md');
+  assert.equal(extractBodyFilePath('gh pr create --body-file="my notes.md"'), 'my notes.md');
+});
+
+test('does not treat a non-flag VAR=value token as a file flag', () => {
+  assert.equal(extractBodyFilePath('FOO=bar git commit -m x'), null);
 });
 
 test('returns null when there is no file (inline body, or stdin "-")', () => {

--- a/src/bodyFile.ts
+++ b/src/bodyFile.ts
@@ -1,0 +1,67 @@
+// bodyFile.ts — find and read a body/message FILE passed to the command, so idempotency
+// covers a block that lives in a file rather than inline in the command string.
+//
+// Handles the flags that read the PR body / commit message from a file:
+//   gh pr create:  --body-file <f> | --body-file=<f> | -F <f> | -F=<f>
+//   git commit:    -F <f> | --file <f> | --file=<f>
+// A path of '-' (stdin) yields null — unreadable from here.
+
+import { readFile, stat } from 'node:fs/promises';
+import { isAbsolute, resolve } from 'node:path';
+
+const FILE_FLAGS = new Set(['--body-file', '--file', '-F']);
+
+// A message/body file is small; refuse to read anything larger so a pathological path
+// can't stall the (synchronous) hook.
+const MAX_BODY_FILE_BYTES = 1_000_000;
+
+function unquote(s: string): string {
+  const t = s.trim();
+  if (
+    t.length >= 2 &&
+    ((t[0] === '"' && t[t.length - 1] === '"') || (t[0] === "'" && t[t.length - 1] === "'"))
+  ) {
+    return t.slice(1, -1);
+  }
+  return t;
+}
+
+/** The path of a body/message file passed to the command, or null if none. */
+export function extractBodyFilePath(command: string): string | null {
+  if (typeof command !== 'string') return null;
+  const tokens = command.split(/\s+/).filter(Boolean);
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i];
+    const eq = t.indexOf('=');
+    if (eq > 0) {
+      // --flag=value
+      if (FILE_FLAGS.has(t.slice(0, eq))) {
+        const val = unquote(t.slice(eq + 1));
+        return val && val !== '-' ? val : null;
+      }
+      continue;
+    }
+    // --flag value
+    if (FILE_FLAGS.has(t)) {
+      const val = unquote(tokens[i + 1] ?? '');
+      return val && val !== '-' ? val : null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Read a body/message file's contents, resolved relative to the command's cwd. Returns
+ * '' when the file is missing, too large, or unreadable — the caller treats that as "no
+ * marker found" (so it proceeds to inject; never a crash). Never throws.
+ */
+export async function readBodyFile(path: string, cwd: string): Promise<string> {
+  try {
+    const full = isAbsolute(path) ? path : resolve(cwd, path);
+    const s = await stat(full);
+    if (!s.isFile() || s.size > MAX_BODY_FILE_BYTES) return '';
+    return await readFile(full, 'utf8');
+  } catch {
+    return '';
+  }
+}

--- a/src/bodyFile.ts
+++ b/src/bodyFile.ts
@@ -15,35 +15,58 @@ const FILE_FLAGS = new Set(['--body-file', '--file', '-F']);
 // can't stall the (synchronous) hook.
 const MAX_BODY_FILE_BYTES = 1_000_000;
 
-function unquote(s: string): string {
-  const t = s.trim();
-  if (
-    t.length >= 2 &&
-    ((t[0] === '"' && t[t.length - 1] === '"') || (t[0] === "'" && t[t.length - 1] === "'"))
-  ) {
-    return t.slice(1, -1);
+/**
+ * Split a command line into tokens, respecting single/double quotes (quotes are consumed,
+ * so a quoted path with spaces survives as ONE token). Not a full shell parser — no
+ * escapes or variable expansion — but enough to read a flag's value reliably.
+ */
+function shellSplit(command: string): string[] {
+  const tokens: string[] = [];
+  let cur = '';
+  let quote: '"' | "'" | null = null;
+  let started = false;
+  for (const ch of command) {
+    if (quote) {
+      if (ch === quote) quote = null;
+      else cur += ch;
+      started = true;
+    } else if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+    } else if (/\s/.test(ch)) {
+      if (started) {
+        tokens.push(cur);
+        cur = '';
+        started = false;
+      }
+    } else {
+      cur += ch;
+      started = true;
+    }
   }
-  return t;
+  if (started) tokens.push(cur);
+  return tokens;
 }
 
-/** The path of a body/message file passed to the command, or null if none. */
+/** The path of a body/message file passed to the command, or null if none. Tokens are
+ * already unquoted by shellSplit, so a quoted path with spaces is handled. */
 export function extractBodyFilePath(command: string): string | null {
   if (typeof command !== 'string') return null;
-  const tokens = command.split(/\s+/).filter(Boolean);
+  const tokens = shellSplit(command);
   for (let i = 0; i < tokens.length; i++) {
     const t = tokens[i];
     const eq = t.indexOf('=');
-    if (eq > 0) {
+    if (eq > 0 && t.startsWith('-')) {
       // --flag=value
       if (FILE_FLAGS.has(t.slice(0, eq))) {
-        const val = unquote(t.slice(eq + 1));
+        const val = t.slice(eq + 1);
         return val && val !== '-' ? val : null;
       }
       continue;
     }
     // --flag value
     if (FILE_FLAGS.has(t)) {
-      const val = unquote(tokens[i + 1] ?? '');
+      const val = tokens[i + 1] ?? '';
       return val && val !== '-' ? val : null;
     }
   }

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -7,7 +7,7 @@
 // aware (PR body vs commit message use different delimiters) and enumerates all four
 // primitives; the model includes only the sections that genuinely apply.
 
-import { HEADINGS, PRIMITIVES, delimiters, type Surface } from './template.js';
+import { renderBlock, type Surface } from './template.js';
 
 // Re-export so existing importers (hook.ts) keep a single import site for Surface.
 export type { Surface } from './template.js';
@@ -29,17 +29,16 @@ function surfaceCopy(surface: Surface): SurfaceCopy {
       };
 }
 
-/** A filled-in-shape example of the block for a surface (headings only, as a template). */
+/** A filled-in-shape example of the block for a surface, rendered from the canonical
+ * template so the guidance can never drift from what the block actually looks like. */
 function exampleBlock(surface: Surface): string {
-  const { open, close } = delimiters(surface);
-  const isPr = surface === 'pr';
-  const lines = [open];
-  for (const key of PRIMITIVES) {
-    lines.push(isPr ? `**${HEADINGS[key]}**` : `${HEADINGS[key]}:`);
-    lines.push('- <one concise line — omit this whole section if it does not apply>');
-  }
-  lines.push(close);
-  return lines.join('\n');
+  const placeholder = ['<one concise line — omit this whole section if it does not apply>'];
+  return renderBlock(surface, {
+    decisions: placeholder,
+    assumptions: placeholder,
+    tradeoffs: placeholder,
+    limitations: placeholder,
+  });
 }
 
 /**

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -4,39 +4,42 @@
 // This text is what the LIVE model reads on the denial and acts on: it composes the
 // forward-only block from the session's real deliberation and re-runs the command. The
 // hook itself never authors the block — it only asks for it. The guidance is surface-
-// aware (PR body vs commit message use different delimiters).
+// aware (PR body vs commit message use different delimiters) and enumerates all four
+// primitives; the model includes only the sections that genuinely apply.
 
-import {
-  PR_MARKER_OPEN,
-  PR_MARKER_CLOSE,
-  COMMIT_MARKER_OPEN,
-  COMMIT_MARKER_CLOSE,
-} from './marker.js';
+import { HEADINGS, PRIMITIVES, delimiters, type Surface } from './template.js';
 
-export type Surface = 'pr' | 'commit';
+// Re-export so existing importers (hook.ts) keep a single import site for Surface.
+export type { Surface } from './template.js';
 
 interface SurfaceCopy {
-  open: string;
-  close: string;
   moment: string;
   where: string;
 }
 
 function surfaceCopy(surface: Surface): SurfaceCopy {
-  if (surface === 'pr') {
-    return {
-      open: PR_MARKER_OPEN,
-      close: PR_MARKER_CLOSE,
-      moment: 'this pull request is opened',
-      where: 'the pull request description (the --body / --body-file text)',
-    };
+  return surface === 'pr'
+    ? {
+        moment: 'this pull request is opened',
+        where: 'the pull request description (the --body / --body-file text)',
+      }
+    : {
+        moment: 'this commit lands on the default branch',
+        where: 'the commit message body',
+      };
+}
+
+/** A filled-in-shape example of the block for a surface (headings only, as a template). */
+function exampleBlock(surface: Surface): string {
+  const { open, close } = delimiters(surface);
+  const isPr = surface === 'pr';
+  const lines = [open];
+  for (const key of PRIMITIVES) {
+    lines.push(isPr ? `**${HEADINGS[key]}**` : `${HEADINGS[key]}:`);
+    lines.push('- <one concise line — omit this whole section if it does not apply>');
   }
-  return {
-    open: COMMIT_MARKER_OPEN,
-    close: COMMIT_MARKER_CLOSE,
-    moment: 'this commit lands on the default branch',
-    where: 'the commit message body',
-  };
+  lines.push(close);
+  return lines.join('\n');
 }
 
 /**
@@ -60,14 +63,9 @@ Rules:
 - Grounded: every line must trace to real deliberation in this session. Cut anything padded, generic, or inferred.
 - If the session had no genuine decisions to record, that's fine — leave it out rather than manufacture filler.
 - Keep it tight: a few lines per section at most.
-- Wrap the block EXACTLY between these two markers so it is detected and left untouched on later runs:
+- Wrap the block EXACTLY between the two markers below so it is detected and left untouched on later runs:
 
-${c.open}
-Decisions:
-- <one concise line per decision>
-Trade-offs:
-- <...>
-${c.close}
+${exampleBlock(surface)}
 
 Then re-run your original command with the block included in ${c.where}.`;
 }

--- a/src/hook.test.ts
+++ b/src/hook.test.ts
@@ -1,5 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { runHook } from './hook.js';
 import { PR_MARKER_OPEN, PR_MARKER_CLOSE } from './marker.js';
 
@@ -35,6 +38,28 @@ test('gh pr create that ALREADY has the block → no-op (idempotent)', async () 
   const cmd = `gh pr create --body "Body ${PR_MARKER_OPEN} Decisions: x ${PR_MARKER_CLOSE}"`;
   const out = await runHook(payload(cmd), onFeature);
   assert.deepEqual(out, {});
+});
+
+test('idempotent when the block lives in a --body-file, not inline', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'arp-hook-'));
+  const withBlock = join(dir, 'body.md');
+  await writeFile(withBlock, `Summary\n${PR_MARKER_OPEN}\nDecisions:\n- x\n${PR_MARKER_CLOSE}\n`);
+  const out = await runHook(
+    payload(`gh pr create --body-file ${withBlock}`, { cwd: dir }),
+    onFeature,
+  );
+  assert.deepEqual(out, {}, 'a file-passed body with a block should be left alone');
+});
+
+test('still denies when the --body-file exists but has NO block', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'arp-hook-'));
+  const noBlock = join(dir, 'body.md');
+  await writeFile(noBlock, 'Just a summary, no reasoning.\n');
+  const out = await runHook(
+    payload(`gh pr create --body-file ${noBlock}`, { cwd: dir }),
+    onFeature,
+  );
+  assert.equal(out.hookSpecificOutput?.permissionDecision, 'deny');
 });
 
 test('git commit on the DEFAULT branch → deny with the commit-surface guidance', async () => {

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -13,6 +13,7 @@
 import { classifyCommand } from './command.js';
 import { hasMarker } from './marker.js';
 import { isDefaultBranch } from './git.js';
+import { extractBodyFilePath, readBodyFile } from './bodyFile.js';
 import { buildGuidance, type Surface } from './guidance.js';
 
 /** The PreToolUse hook output. `{}` = no injection (fail-open); otherwise a deny. */
@@ -59,11 +60,18 @@ export async function runHook(rawStdin: string, deps: HookDeps = {}): Promise<Pr
     const kind = classifyCommand(command);
     if (kind === 'other') return {};
 
+    const cwd = typeof rec.cwd === 'string' && rec.cwd ? rec.cwd : (deps.cwd ?? process.cwd());
+
     // Idempotency: the command already carries a block (the model's own retry, or a
     // hand-written one) → leave it alone, so a re-run is a no-op and we never re-deny.
+    // This covers the inline body (--body / -m) AND a body/message passed via a file
+    // (--body-file / -F / --file) — we read that file and check it too.
     if (hasMarker(command)) return {};
-
-    const cwd = typeof rec.cwd === 'string' && rec.cwd ? rec.cwd : (deps.cwd ?? process.cwd());
+    const bodyFilePath = extractBodyFilePath(command);
+    if (bodyFilePath) {
+      const contents = await readBodyFile(bodyFilePath, cwd);
+      if (hasMarker(contents)) return {};
+    }
 
     // Surface routing: `gh pr create` → the PR body. A `git commit` only gets a block on
     // the DEFAULT branch (the direct-push surface); a feature-branch commit defers to

--- a/src/template.test.ts
+++ b/src/template.test.ts
@@ -1,0 +1,46 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderBlock, isEmptyBlock } from './template.js';
+import { hasMarker, PR_MARKER_OPEN, PR_MARKER_CLOSE, COMMIT_MARKER_OPEN } from './marker.js';
+
+test('renders the PR surface: invisible HTML-comment delimiters, markdown headings, only non-empty sections', () => {
+  const block = renderBlock('pr', { decisions: ['chose X over Y'], tradeoffs: ['gave up Z'] });
+  assert.ok(block.startsWith(PR_MARKER_OPEN));
+  assert.ok(block.trimEnd().endsWith(PR_MARKER_CLOSE));
+  assert.match(block, /\*\*Decisions\*\*/);
+  assert.match(block, /- chose X over Y/);
+  assert.match(block, /\*\*Trade-offs\*\*/);
+  // Sections with no items are omitted entirely.
+  assert.doesNotMatch(block, /Assumptions/);
+  assert.doesNotMatch(block, /Limitations/);
+  assert.equal(hasMarker(block), true);
+});
+
+test('renders the commit surface: plain sentinel delimiters and plain-text headings', () => {
+  const block = renderBlock('commit', { decisions: ['keep it local'] });
+  assert.ok(block.startsWith(COMMIT_MARKER_OPEN));
+  assert.match(block, /Decisions:/);
+  assert.doesNotMatch(block, /\*\*Decisions\*\*/); // no markdown bold in a commit message
+  assert.equal(hasMarker(block), true);
+});
+
+test('renders sections in canonical order regardless of input order', () => {
+  const block = renderBlock('commit', {
+    limitations: ['l'],
+    decisions: ['d'],
+    tradeoffs: ['t'],
+    assumptions: ['a'],
+  });
+  const order = ['Decisions', 'Assumptions', 'Trade-offs', 'Limitations'].map((h) =>
+    block.indexOf(h),
+  );
+  assert.deepEqual(order, [...order].sort((x, y) => x - y));
+});
+
+test('empty primitives render nothing (leave-empty → omit the block)', () => {
+  assert.equal(renderBlock('pr', {}), '');
+  assert.equal(renderBlock('commit', { decisions: [], tradeoffs: ['   '] }), '');
+  assert.equal(isEmptyBlock({}), true);
+  assert.equal(isEmptyBlock({ decisions: ['  ', ''] }), true);
+  assert.equal(isEmptyBlock({ assumptions: ['real'] }), false);
+});

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,0 +1,82 @@
+// template.ts — the canonical forward-only "why" block: its four primitives, the
+// surface-appropriate delimiters, and a renderer.
+//
+// The block is AUTHORED by the live model, but this module defines its SHAPE — the
+// primitive set + order, the per-surface delimiters, the "only non-empty sections" and
+// "empty → omit the whole block" rules — so the guidance we inject, the tests, and the
+// multi-session scratchpad all agree on exactly one format.
+
+import {
+  PR_MARKER_OPEN,
+  PR_MARKER_CLOSE,
+  COMMIT_MARKER_OPEN,
+  COMMIT_MARKER_CLOSE,
+} from './marker.js';
+
+/** Where a block lands: a PR description (markdown) or a commit message (plain text). */
+export type Surface = 'pr' | 'commit';
+
+/** The four forward-only primitives, in canonical render order. */
+export const PRIMITIVES = ['decisions', 'assumptions', 'tradeoffs', 'limitations'] as const;
+export type PrimitiveKey = (typeof PRIMITIVES)[number];
+
+export interface WhyPrimitives {
+  /** The choices made and why (not what changed — the diff shows that). */
+  decisions?: string[];
+  /** What was taken as given that a reviewer should confirm. */
+  assumptions?: string[];
+  /** What was knowingly given up, and the rejected alternative. */
+  tradeoffs?: string[];
+  /** Known gaps, risks, or deliberately-deferred follow-ups. */
+  limitations?: string[];
+}
+
+/** Human headings for each primitive (canonical wording). */
+export const HEADINGS: Record<PrimitiveKey, string> = {
+  decisions: 'Decisions',
+  assumptions: 'Assumptions',
+  tradeoffs: 'Trade-offs',
+  limitations: 'Limitations',
+};
+
+export function delimiters(surface: Surface): { open: string; close: string } {
+  return surface === 'pr'
+    ? { open: PR_MARKER_OPEN, close: PR_MARKER_CLOSE }
+    : { open: COMMIT_MARKER_OPEN, close: COMMIT_MARKER_CLOSE };
+}
+
+/** Trim + drop blank entries from a primitive's items. */
+function clean(items: string[] | undefined): string[] {
+  if (!Array.isArray(items)) return [];
+  return items.map((s) => (typeof s === 'string' ? s.trim() : '')).filter(Boolean);
+}
+
+/** True if the primitives carry nothing worth recording (→ the block is omitted). */
+export function isEmptyBlock(p: WhyPrimitives): boolean {
+  return PRIMITIVES.every((k) => clean(p[k]).length === 0);
+}
+
+/**
+ * Render the block for a surface, including ONLY the non-empty sections in canonical
+ * order, wrapped in that surface's delimiters. Returns '' when nothing is worth
+ * recording (the "leave empty → omit the block" rule) so callers can drop it entirely.
+ *
+ * PR bodies render as markdown (bold headings — the delimiters are invisible HTML
+ * comments); commit messages render as plain text between sentinel lines.
+ */
+export function renderBlock(surface: Surface, p: WhyPrimitives): string {
+  if (isEmptyBlock(p)) return '';
+  const { open, close } = delimiters(surface);
+  const isPr = surface === 'pr';
+  const lines: string[] = [open];
+  for (const key of PRIMITIVES) {
+    const items = clean(p[key]);
+    if (items.length === 0) continue;
+    lines.push(isPr ? `**${HEADINGS[key]}**` : `${HEADINGS[key]}:`);
+    for (const item of items) lines.push(`- ${item}`);
+    if (isPr) lines.push(''); // a blank line between markdown sections
+  }
+  while (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+  lines.push(close);
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Why-block template + delimiter + idempotency

Formalizes the block's shape and closes the file-body idempotency gap flagged on the harness PR.

### Template (`template.ts`)
The canonical definition of the block, so the injected guidance, the tests, and the (upcoming) multi-session scratchpad all agree on one format:
- The four forward-only primitives in canonical order: **Decisions / Assumptions / Trade-offs / Limitations**.
- Surface-aware delimiters: an invisible **HTML comment** in a PR body (markdown, bold headings) vs. a plain **sentinel** in a commit message (plain-text headings).
- Only non-empty sections render; if **nothing** is worth recording, `renderBlock` returns `''` — the "leave empty → omit the whole block" rule, in code.

### Guidance (`guidance.ts`)
Now enumerates all four primitives and generates the injected example block from the same `template.ts` source (one format, no drift), per surface.

### Idempotency — now covers file-passed bodies (`bodyFile.ts` + `hook.ts`)
The harness previously only inspected the inline command string, so a block passed via `gh pr create --body-file <f>` / `git commit -F <f>` / `--file <f>` wouldn't be recognized (the deferred `[low]` finding). It now extracts that path and reads the file (resolved against the command's cwd, size-capped, never throws) and skips re-injection when the file already carries a block.

### Done when
- **Renders in both surfaces** — verified: PR (invisible HTML-comment delimiters + markdown) and commit (sentinel + plain text), canonical ordering, empty-case omission.
- **Second run on a block-bearing PR is a no-op** — verified for both the inline body and a `--body-file`, through the built bundle.

### Testing
- `npm run typecheck` clean; `npm test` 32/32.
- Through `dist-bundle/... hook`: `--body-file` with a block → `{}`; `--body-file` without one → deny listing all four primitives.
