### PR TITLE
Surface routing + trigger controls (off-switch, skip, anti-loop cap)

### DIFF
--- a/dist-bundle/add-reasoning-to-prs.js
+++ b/dist-bundle/add-reasoning-to-prs.js
@@ -93,12 +93,12 @@ async function defaultBranch(cwd) {
   if (head) return head.replace(/^origin\//, "");
   return null;
 }
-async function isDefaultBranch(cwd) {
+async function branchInfo(cwd) {
   const current = await currentBranch(cwd);
-  if (!current) return false;
+  if (!current) return { current: null, isDefault: false };
   const def = await defaultBranch(cwd);
-  if (def) return current === def;
-  return current === "main" || current === "master";
+  const isDefault = def ? current === def : current === "main" || current === "master";
+  return { current, isDefault };
 }
 
 // src/bodyFile.ts
@@ -161,6 +161,82 @@ async function readBodyFile(path, cwd) {
     return await readFile(full, "utf8");
   } catch {
     return "";
+  }
+}
+
+// src/repoConfig.ts
+import { execFile as execFile2 } from "node:child_process";
+import { promisify as promisify2 } from "node:util";
+var pexec2 = promisify2(execFile2);
+var SKIP_TOKEN = "[skip-why]";
+function envTrue(v) {
+  if (typeof v !== "string") return false;
+  const s = v.trim().toLowerCase();
+  return s === "1" || s === "true" || s === "yes" || s === "on";
+}
+async function isDisabled(cwd, env = process.env) {
+  if (envTrue(env.ADD_REASONING_TO_PRS_DISABLE)) return true;
+  try {
+    const { stdout } = await pexec2(
+      "git",
+      ["config", "--get", "add-reasoning-to-prs.disabled"],
+      { cwd, timeout: 3e3, windowsHide: true }
+    );
+    return envTrue(stdout);
+  } catch {
+    return false;
+  }
+}
+function isSkipped(command, env = process.env) {
+  if (envTrue(env.ADD_REASONING_TO_PRS_SKIP)) return true;
+  return typeof command === "string" && command.includes(SKIP_TOKEN);
+}
+
+// src/promptState.ts
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { readFile as readFile2, writeFile, mkdir, chmod } from "node:fs/promises";
+var DIR_MODE = 448;
+var FILE_MODE = 384;
+var MAX_KEYS = 500;
+function stateDir(env = process.env) {
+  const override = env.ADD_REASONING_TO_PRS_STATE_DIR;
+  return override && override.trim().length > 0 ? override : join(homedir(), ".add-reasoning-to-prs");
+}
+function statePath(env) {
+  return join(stateDir(env), "prompted");
+}
+function promptKey(sessionId, surface, branch) {
+  return `${sessionId ?? "no-session"}::${surface}::${branch ?? "no-branch"}`;
+}
+async function hasPrompted(key, env = process.env) {
+  try {
+    const raw = await readFile2(statePath(env), "utf8");
+    return raw.split("\n").some((line) => line.trim() === key);
+  } catch (e) {
+    return e?.code === "ENOENT" ? false : true;
+  }
+}
+async function markPrompted(key, env = process.env) {
+  try {
+    const dir = stateDir(env);
+    await mkdir(dir, { recursive: true, mode: DIR_MODE });
+    let keys = [];
+    try {
+      const raw = await readFile2(statePath(env), "utf8");
+      keys = raw.split("\n").map((s) => s.trim()).filter(Boolean);
+    } catch {
+    }
+    if (keys.includes(key)) return true;
+    keys.push(key);
+    if (keys.length > MAX_KEYS) keys = keys.slice(keys.length - MAX_KEYS);
+    const path = statePath(env);
+    await writeFile(path, keys.join("\n") + "\n", { mode: FILE_MODE });
+    await chmod(path, FILE_MODE).catch(() => {
+    });
+    return true;
+  } catch {
+    return false;
   }
 }
 
@@ -242,7 +318,22 @@ Then re-run your original command with the block included in ${c.where}.`;
 }
 
 // src/hook.ts
+function deny(surface) {
+  const guidance = buildGuidance(surface);
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: guidance,
+      // Progressive enhancement. Claude Code exposes no version signal to hooks, so we
+      // always emit additionalContext too: newer versions surface it, older ones ignore
+      // the unknown field, and the reason above carries the guidance either way.
+      additionalContext: guidance
+    }
+  };
+}
 async function runHook(rawStdin, deps = {}) {
+  const env = deps.env ?? process.env;
   try {
     let payload;
     try {
@@ -257,33 +348,28 @@ async function runHook(rawStdin, deps = {}) {
     if (typeof command !== "string" || command.trim().length === 0) return {};
     const kind = classifyCommand(command);
     if (kind === "other") return {};
+    if (isSkipped(command, env)) return {};
     const cwd = typeof rec.cwd === "string" && rec.cwd ? rec.cwd : deps.cwd ?? process.cwd();
     if (hasMarker(command)) return {};
     const bodyFilePath = extractBodyFilePath(command);
-    if (bodyFilePath) {
-      const contents = await readBodyFile(bodyFilePath, cwd);
-      if (hasMarker(contents)) return {};
-    }
+    if (bodyFilePath && hasMarker(await readBodyFile(bodyFilePath, cwd))) return {};
+    if (await (deps.isDisabledImpl ?? isDisabled)(cwd, env)) return {};
+    const info = await (deps.branchInfoImpl ?? branchInfo)(cwd).catch(() => ({
+      current: null,
+      isDefault: false
+    }));
     let surface;
     if (kind === "gh-pr-create") {
       surface = "pr";
     } else {
-      const onDefault = await (deps.isDefaultBranchImpl ?? isDefaultBranch)(cwd).catch(() => false);
-      if (!onDefault) return {};
+      if (!info.isDefault) return {};
       surface = "commit";
     }
-    const guidance = buildGuidance(surface);
-    return {
-      hookSpecificOutput: {
-        hookEventName: "PreToolUse",
-        permissionDecision: "deny",
-        permissionDecisionReason: guidance,
-        // Progressive enhancement. Claude Code exposes no version signal to hooks, so we
-        // always emit additionalContext too: newer versions surface it, older ones ignore
-        // the unknown field, and the reason above carries the guidance either way.
-        additionalContext: guidance
-      }
-    };
+    const sessionId = typeof rec.session_id === "string" ? rec.session_id : void 0;
+    const key = promptKey(sessionId, surface, info.current);
+    if (await hasPrompted(key, env)) return {};
+    if (!await markPrompted(key, env)) return {};
+    return deny(surface);
   } catch {
     return {};
   }

--- a/src/git.ts
+++ b/src/git.ts
@@ -38,15 +38,24 @@ export async function defaultBranch(cwd: string): Promise<string | null> {
   return null;
 }
 
+export interface BranchInfo {
+  /** The current branch name, or null (detached HEAD / non-repo / error). */
+  current: string | null;
+  /** Whether `current` is the repo's default branch. */
+  isDefault: boolean;
+}
+
 /**
- * True if the current branch is the repo's default branch. When the remote default is
- * unknown (no origin/HEAD), fall back to the conventional names — a direct commit onto
- * `main`/`master` is the case we care about. Any error → false (defer / do nothing).
+ * The current branch name AND whether it's the repo's default — resolved in one pass so
+ * the caller needn't query git twice (it needs the name for the deny-cap key and the
+ * default-ness for surface routing). When the remote default is unknown (no origin/HEAD),
+ * fall back to the conventional names — a direct commit onto `main`/`master` is the case
+ * we care about. Any error → `{ current: null, isDefault: false }` (defer / do nothing).
  */
-export async function isDefaultBranch(cwd: string): Promise<boolean> {
+export async function branchInfo(cwd: string): Promise<BranchInfo> {
   const current = await currentBranch(cwd);
-  if (!current) return false;
+  if (!current) return { current: null, isDefault: false };
   const def = await defaultBranch(cwd);
-  if (def) return current === def;
-  return current === 'main' || current === 'master';
+  const isDefault = def ? current === def : current === 'main' || current === 'master';
+  return { current, isDefault };
 }

--- a/src/hook.test.ts
+++ b/src/hook.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { runHook } from './hook.js';
+import { runHook, type HookDeps } from './hook.js';
 import { PR_MARKER_OPEN, PR_MARKER_CLOSE } from './marker.js';
 
 /** Build a PreToolUse/Bash payload string. */
@@ -18,36 +18,44 @@ function payload(command: string, extra: Record<string, unknown> = {}): string {
   });
 }
 
-const onDefault = { isDefaultBranchImpl: async () => true };
-const onFeature = { isDefaultBranchImpl: async () => false };
+const AS_DEFAULT: Pick<HookDeps, 'branchInfoImpl'> = {
+  branchInfoImpl: async () => ({ current: 'main', isDefault: true }),
+};
+const AS_FEATURE: Pick<HookDeps, 'branchInfoImpl'> = {
+  branchInfoImpl: async () => ({ current: 'feat/x', isDefault: false }),
+};
+
+/** Deps with an isolated (empty) cap-state dir and the off-switch stubbed off. */
+async function mkDeps(over: HookDeps = {}): Promise<HookDeps> {
+  const dir = await mkdtemp(join(tmpdir(), 'arp-state-'));
+  return {
+    isDisabledImpl: async () => false,
+    env: { ADD_REASONING_TO_PRS_STATE_DIR: dir },
+    ...over,
+  };
+}
 
 test('gh pr create without a block → deny with guidance (both channels)', async () => {
-  const out = await runHook(payload('gh pr create --title T --body B'), onFeature);
+  const out = await runHook(payload('gh pr create --title T --body B'), await mkDeps(AS_FEATURE));
   const hs = out.hookSpecificOutput;
   assert.ok(hs, 'expected a hookSpecificOutput');
   assert.equal(hs.hookEventName, 'PreToolUse');
   assert.equal(hs.permissionDecision, 'deny');
   assert.match(hs.permissionDecisionReason, /forward-only/i);
   assert.match(hs.permissionDecisionReason, /pull request description/i);
-  // The reason (reliable floor) and additionalContext (progressive enhancement) both
-  // carry the guidance, so the model sees it regardless of version support.
   assert.equal(hs.additionalContext, hs.permissionDecisionReason);
 });
 
 test('gh pr create that ALREADY has the block → no-op (idempotent)', async () => {
   const cmd = `gh pr create --body "Body ${PR_MARKER_OPEN} Decisions: x ${PR_MARKER_CLOSE}"`;
-  const out = await runHook(payload(cmd), onFeature);
-  assert.deepEqual(out, {});
+  assert.deepEqual(await runHook(payload(cmd), await mkDeps(AS_FEATURE)), {});
 });
 
 test('idempotent when the block lives in a --body-file, not inline', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'arp-hook-'));
   const withBlock = join(dir, 'body.md');
   await writeFile(withBlock, `Summary\n${PR_MARKER_OPEN}\nDecisions:\n- x\n${PR_MARKER_CLOSE}\n`);
-  const out = await runHook(
-    payload(`gh pr create --body-file ${withBlock}`, { cwd: dir }),
-    onFeature,
-  );
+  const out = await runHook(payload(`gh pr create --body-file ${withBlock}`), await mkDeps(AS_FEATURE));
   assert.deepEqual(out, {}, 'a file-passed body with a block should be left alone');
 });
 
@@ -55,49 +63,93 @@ test('still denies when the --body-file exists but has NO block', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'arp-hook-'));
   const noBlock = join(dir, 'body.md');
   await writeFile(noBlock, 'Just a summary, no reasoning.\n');
-  const out = await runHook(
-    payload(`gh pr create --body-file ${noBlock}`, { cwd: dir }),
-    onFeature,
-  );
+  const out = await runHook(payload(`gh pr create --body-file ${noBlock}`), await mkDeps(AS_FEATURE));
   assert.equal(out.hookSpecificOutput?.permissionDecision, 'deny');
 });
 
 test('git commit on the DEFAULT branch → deny with the commit-surface guidance', async () => {
-  const out = await runHook(payload('git commit -m "wip"'), onDefault);
-  const hs = out.hookSpecificOutput;
-  assert.ok(hs);
-  assert.equal(hs.permissionDecision, 'deny');
-  assert.match(hs.permissionDecisionReason, /commit message body/i);
+  const out = await runHook(payload('git commit -m "wip"'), await mkDeps(AS_DEFAULT));
+  assert.equal(out.hookSpecificOutput?.permissionDecision, 'deny');
+  assert.match(out.hookSpecificOutput!.permissionDecisionReason, /commit message body/i);
 });
 
 test('git commit on a FEATURE branch → no-op (defers to PR-create)', async () => {
-  const out = await runHook(payload('git commit -m "wip"'), onFeature);
-  assert.deepEqual(out, {});
+  assert.deepEqual(await runHook(payload('git commit -m "wip"'), await mkDeps(AS_FEATURE)), {});
 });
 
-test('non-matching command → no-op', async () => {
-  assert.deepEqual(await runHook(payload('git push'), onDefault), {});
-  assert.deepEqual(await runHook(payload('ls -la'), onDefault), {});
-});
-
-test('non-Bash tool → no-op', async () => {
-  const raw = JSON.stringify({ tool_name: 'Read', tool_input: { file_path: '/x' } });
-  assert.deepEqual(await runHook(raw, onDefault), {});
+test('non-matching command / non-Bash tool → no-op', async () => {
+  assert.deepEqual(await runHook(payload('git push'), await mkDeps(AS_DEFAULT)), {});
+  assert.deepEqual(await runHook(payload('ls -la'), await mkDeps(AS_DEFAULT)), {});
+  const read = JSON.stringify({ tool_name: 'Read', tool_input: { file_path: '/x' } });
+  assert.deepEqual(await runHook(read, await mkDeps(AS_DEFAULT)), {});
 });
 
 test('fail-open on bad / empty / missing input', async () => {
-  assert.deepEqual(await runHook('not json', onDefault), {});
-  assert.deepEqual(await runHook('', onDefault), {});
-  assert.deepEqual(await runHook('null', onDefault), {});
-  assert.deepEqual(await runHook(JSON.stringify({ tool_name: 'Bash', tool_input: {} }), onDefault), {});
+  const d = await mkDeps(AS_DEFAULT);
+  assert.deepEqual(await runHook('not json', d), {});
+  assert.deepEqual(await runHook('', d), {});
+  assert.deepEqual(await runHook('null', d), {});
+  assert.deepEqual(await runHook(JSON.stringify({ tool_name: 'Bash', tool_input: {} }), d), {});
 });
 
-test('fail-open when the branch check throws (git commit) → no-op, never a throw', async () => {
-  const throwing = {
-    isDefaultBranchImpl: async () => {
+test('fail-open when the branch check throws (git commit) → no-op', async () => {
+  const deps = await mkDeps({
+    branchInfoImpl: async () => {
       throw new Error('git blew up');
     },
-  };
-  const out = await runHook(payload('git commit -m x'), throwing);
+  });
+  assert.deepEqual(await runHook(payload('git commit -m x'), deps), {});
+});
+
+// --- trigger controls -------------------------------------------------------------
+
+test('per-invocation skip: [skip-why] token in the command → no-op', async () => {
+  const out = await runHook(
+    payload('gh pr create --title T --body "B [skip-why]"'),
+    await mkDeps(AS_FEATURE),
+  );
   assert.deepEqual(out, {});
+});
+
+test('env skip flag → no-op', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'arp-state-'));
+  const out = await runHook(payload('gh pr create --title T'), {
+    ...AS_FEATURE,
+    isDisabledImpl: async () => false,
+    env: { ADD_REASONING_TO_PRS_STATE_DIR: dir, ADD_REASONING_TO_PRS_SKIP: '1' },
+  });
+  assert.deepEqual(out, {});
+});
+
+test('per-repo off switch (disabled) → no-op', async () => {
+  const out = await runHook(
+    payload('gh pr create --title T'),
+    await mkDeps({ ...AS_FEATURE, isDisabledImpl: async () => true }),
+  );
+  assert.deepEqual(out, {});
+});
+
+// --- anti-loop deny cap -----------------------------------------------------------
+
+test('deny cap: the same operation is denied at most once (empty-retry does not loop)', async () => {
+  const deps = await mkDeps(AS_FEATURE); // shared env (shared cap state) across both calls
+  const first = await runHook(payload('gh pr create --title T'), deps);
+  assert.equal(first.hookSpecificOutput?.permissionDecision, 'deny', 'first prompt denies');
+  // The model finds nothing to add and re-runs the SAME command with no block:
+  const second = await runHook(payload('gh pr create --title T'), deps);
+  assert.deepEqual(second, {}, 'second time is capped → allow (no loop)');
+});
+
+test('deny cap: a different branch (distinct PR) in the same session is still prompted', async () => {
+  const deps = await mkDeps(); // shared env
+  const a = await runHook(payload('gh pr create --title A'), {
+    ...deps,
+    branchInfoImpl: async () => ({ current: 'feat/a', isDefault: false }),
+  });
+  const b = await runHook(payload('gh pr create --title B'), {
+    ...deps,
+    branchInfoImpl: async () => ({ current: 'feat/b', isDefault: false }),
+  });
+  assert.equal(a.hookSpecificOutput?.permissionDecision, 'deny');
+  assert.equal(b.hookSpecificOutput?.permissionDecision, 'deny', 'distinct branch → not capped');
 });

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -2,18 +2,21 @@
 //
 // Claude Code runs this synchronously BEFORE a Bash tool call and reads its stdout for a
 // decision. When the command is a `git commit` (on the default branch) or a `gh pr create`
-// that lacks a why-block, we DENY with a reason + injected guidance, so the live model
-// composes the block and re-runs the command. Everything else → an empty `{}` (no
-// injection, the tool proceeds).
+// that lacks a why-block — and the hook is enabled and not skipped — we DENY once with a
+// reason + injected guidance, so the live model composes the block and re-runs. Everything
+// else → an empty `{}` (no injection, the tool proceeds).
 //
 // NON-NEGOTIABLE POSTURE (fail-open): this must NEVER block or delay the user's git op.
-// Every failure mode — unparseable payload, missing git, a throw anywhere — resolves to
-// `{}` and exit 0. It never exits 2, never hard-blocks.
+// Every failure mode — unparseable payload, missing git, unwritable state, a throw
+// anywhere — resolves to `{}` and exit 0. It never exits 2, never hard-blocks, and (via
+// the deny cap) never denies the same operation twice.
 
 import { classifyCommand } from './command.js';
 import { hasMarker } from './marker.js';
-import { isDefaultBranch } from './git.js';
+import { branchInfo } from './git.js';
 import { extractBodyFilePath, readBodyFile } from './bodyFile.js';
+import { isDisabled, isSkipped } from './repoConfig.js';
+import { hasPrompted, markPrompted, promptKey } from './promptState.js';
 import { buildGuidance, type Surface } from './guidance.js';
 
 /** The PreToolUse hook output. `{}` = no injection (fail-open); otherwise a deny. */
@@ -29,8 +32,27 @@ export interface PreToolUseHookOutput {
 export interface HookDeps {
   /** Fallback cwd when the payload omits one. Defaults to process.cwd(). */
   cwd?: string;
-  /** Test seam: the default-branch check. Defaults to git.isDefaultBranch. */
-  isDefaultBranchImpl?: (cwd: string) => Promise<boolean>;
+  /** Environment (skip/disable flags + state-dir override). Defaults to process.env. */
+  env?: NodeJS.ProcessEnv;
+  /** Test seam: current-branch + default-ness. Defaults to git.branchInfo. */
+  branchInfoImpl?: (cwd: string) => Promise<{ current: string | null; isDefault: boolean }>;
+  /** Test seam: the per-repo/global off switch. Defaults to repoConfig.isDisabled. */
+  isDisabledImpl?: (cwd: string, env: NodeJS.ProcessEnv) => Promise<boolean>;
+}
+
+function deny(surface: Surface): PreToolUseHookOutput {
+  const guidance = buildGuidance(surface);
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: guidance,
+      // Progressive enhancement. Claude Code exposes no version signal to hooks, so we
+      // always emit additionalContext too: newer versions surface it, older ones ignore
+      // the unknown field, and the reason above carries the guidance either way.
+      additionalContext: guidance,
+    },
+  };
 }
 
 /**
@@ -38,6 +60,7 @@ export interface HookDeps {
  * yields `{}` (no injection; the git op proceeds).
  */
 export async function runHook(rawStdin: string, deps: HookDeps = {}): Promise<PreToolUseHookOutput> {
+  const env = deps.env ?? process.env;
   try {
     let payload: unknown;
     try {
@@ -60,43 +83,45 @@ export async function runHook(rawStdin: string, deps: HookDeps = {}): Promise<Pr
     const kind = classifyCommand(command);
     if (kind === 'other') return {};
 
+    // Per-invocation skip (a [skip-why] token in the command, or the env flag). Cheap
+    // string check — do it before any git/filesystem work.
+    if (isSkipped(command, env)) return {};
+
     const cwd = typeof rec.cwd === 'string' && rec.cwd ? rec.cwd : (deps.cwd ?? process.cwd());
 
     // Idempotency: the command already carries a block (the model's own retry, or a
-    // hand-written one) → leave it alone, so a re-run is a no-op and we never re-deny.
-    // This covers the inline body (--body / -m) AND a body/message passed via a file
-    // (--body-file / -F / --file) — we read that file and check it too.
+    // hand-written one), inline or in a --body-file/-F/--file → leave it alone.
     if (hasMarker(command)) return {};
     const bodyFilePath = extractBodyFilePath(command);
-    if (bodyFilePath) {
-      const contents = await readBodyFile(bodyFilePath, cwd);
-      if (hasMarker(contents)) return {};
-    }
+    if (bodyFilePath && hasMarker(await readBodyFile(bodyFilePath, cwd))) return {};
 
-    // Surface routing: `gh pr create` → the PR body. A `git commit` only gets a block on
-    // the DEFAULT branch (the direct-push surface); a feature-branch commit defers to
-    // PR-create and is left alone here.
+    // Per-repo / global off switch.
+    if (await (deps.isDisabledImpl ?? isDisabled)(cwd, env)) return {};
+
+    // Surface routing (one git query for both the name and default-ness):
+    // `gh pr create` → the PR body. A `git commit` gets a block only on the DEFAULT branch
+    // (the direct-push surface); a feature-branch commit defers to PR-create.
+    const info = await (deps.branchInfoImpl ?? branchInfo)(cwd).catch(() => ({
+      current: null as string | null,
+      isDefault: false,
+    }));
     let surface: Surface;
     if (kind === 'gh-pr-create') {
       surface = 'pr';
     } else {
-      const onDefault = await (deps.isDefaultBranchImpl ?? isDefaultBranch)(cwd).catch(() => false);
-      if (!onDefault) return {};
+      if (!info.isDefault) return {};
       surface = 'commit';
     }
 
-    const guidance = buildGuidance(surface);
-    return {
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        permissionDecision: 'deny',
-        permissionDecisionReason: guidance,
-        // Progressive enhancement. Claude Code exposes no version signal to hooks, so we
-        // always emit additionalContext too: newer versions surface it, older ones ignore
-        // the unknown field, and the reason above carries the guidance either way.
-        additionalContext: guidance,
-      },
-    };
+    // Anti-loop DENY CAP: deny at most once per (session, surface, branch). We deny ONLY
+    // after recording the cap; if we've already prompted, or can't persist the cap, we
+    // stand down — so the same operation is never denied twice (see promptState.ts).
+    const sessionId = typeof rec.session_id === 'string' ? rec.session_id : undefined;
+    const key = promptKey(sessionId, surface, info.current);
+    if (await hasPrompted(key, env)) return {};
+    if (!(await markPrompted(key, env))) return {};
+
+    return deny(surface);
   } catch {
     return {}; // belt-and-braces: any failure → no injection, the git op proceeds
   }

--- a/src/promptState.test.ts
+++ b/src/promptState.test.ts
@@ -1,0 +1,35 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { hasPrompted, markPrompted, promptKey } from './promptState.js';
+
+async function freshEnv(): Promise<NodeJS.ProcessEnv> {
+  const dir = await mkdtemp(join(tmpdir(), 'arp-prompt-'));
+  return { ADD_REASONING_TO_PRS_STATE_DIR: dir };
+}
+
+test('promptKey distinguishes surface and branch, and tolerates a missing session', () => {
+  assert.equal(promptKey('s1', 'pr', 'feat/a'), 's1::pr::feat/a');
+  assert.notEqual(promptKey('s1', 'pr', 'feat/a'), promptKey('s1', 'pr', 'feat/b'));
+  assert.notEqual(promptKey('s1', 'pr', 'main'), promptKey('s1', 'commit', 'main'));
+  assert.match(promptKey(undefined, 'pr', null), /no-session::pr::no-branch/);
+});
+
+test('first run is not prompted; after markPrompted it is (and mark is idempotent)', async () => {
+  const env = await freshEnv();
+  const key = promptKey('s1', 'pr', 'feat/a');
+  assert.equal(await hasPrompted(key, env), false, 'ENOENT / first run → not prompted');
+  assert.equal(await markPrompted(key, env), true, 'mark persists → true');
+  assert.equal(await hasPrompted(key, env), true, 'now prompted');
+  assert.equal(await markPrompted(key, env), true, 're-marking an existing key is fine');
+});
+
+test('distinct keys are tracked independently', async () => {
+  const env = await freshEnv();
+  await markPrompted(promptKey('s1', 'pr', 'feat/a'), env);
+  assert.equal(await hasPrompted(promptKey('s1', 'pr', 'feat/a'), env), true);
+  assert.equal(await hasPrompted(promptKey('s1', 'pr', 'feat/b'), env), false);
+  assert.equal(await hasPrompted(promptKey('s2', 'pr', 'feat/a'), env), false);
+});

--- a/src/promptState.ts
+++ b/src/promptState.ts
@@ -1,0 +1,91 @@
+// promptState.ts — the anti-loop DENY CAP.
+//
+// The hook denies in order to PROMPT the model for a block, but it must deny each
+// operation AT MOST ONCE: if the model concludes the session had nothing worth recording
+// and re-runs the command with no block, we have to let it through rather than deny
+// forever. So we remember, per (session, surface, branch), that we already prompted — and
+// stand down on the next matching command for that key.
+//
+// LOOP-SAFE BY CONSTRUCTION. Two invariants, enforced together with runHook:
+//   1. `hasPrompted` returns false ONLY for a missing state file (first run) or a clean
+//      read with the key absent; ANY other read problem returns true (→ allow), so a
+//      broken/torn state file degrades to "never prompt", never to a deny-loop.
+//   2. runHook denies ONLY after `markPrompted` reports success. If we can't persist the
+//      cap, we don't deny — so we can never deny a second time for the same operation.
+//
+// State lives in a small newline-delimited file (append-membership, so it can't "corrupt"
+// like JSON) under ~/.add-reasoning-to-prs, overridable via ADD_REASONING_TO_PRS_STATE_DIR.
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { readFile, writeFile, mkdir, chmod } from 'node:fs/promises';
+
+const DIR_MODE = 0o700;
+const FILE_MODE = 0o600;
+const MAX_KEYS = 500; // bounded ring; oldest keys fall off so the file stays tiny
+
+export function stateDir(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.ADD_REASONING_TO_PRS_STATE_DIR;
+  return override && override.trim().length > 0 ? override : join(homedir(), '.add-reasoning-to-prs');
+}
+
+function statePath(env: NodeJS.ProcessEnv): string {
+  return join(stateDir(env), 'prompted');
+}
+
+/** The cap key for one operation. Keyed on branch so distinct PRs (distinct branches) in
+ * one session are each prompted; a re-run of the SAME operation shares the key. */
+export function promptKey(
+  sessionId: string | undefined,
+  surface: string,
+  branch: string | null,
+): string {
+  return `${sessionId ?? 'no-session'}::${surface}::${branch ?? 'no-branch'}`;
+}
+
+/**
+ * True if we've already prompted for this key — or if we can't be sure. Only a missing
+ * file (first run) or a clean read with the key absent returns false; a read error on an
+ * existing file returns true (play safe → don't deny again).
+ */
+export async function hasPrompted(
+  key: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<boolean> {
+  try {
+    const raw = await readFile(statePath(env), 'utf8');
+    return raw.split('\n').some((line) => line.trim() === key);
+  } catch (e) {
+    return (e as NodeJS.ErrnoException)?.code === 'ENOENT' ? false : true;
+  }
+}
+
+/**
+ * Record that we prompted for this key. Returns true if the cap is now persisted (either
+ * newly written or already present), false if we could not persist it. Never throws.
+ */
+export async function markPrompted(
+  key: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<boolean> {
+  try {
+    const dir = stateDir(env);
+    await mkdir(dir, { recursive: true, mode: DIR_MODE });
+    let keys: string[] = [];
+    try {
+      const raw = await readFile(statePath(env), 'utf8');
+      keys = raw.split('\n').map((s) => s.trim()).filter(Boolean);
+    } catch {
+      // no existing file (or unreadable) → start fresh
+    }
+    if (keys.includes(key)) return true; // already recorded
+    keys.push(key);
+    if (keys.length > MAX_KEYS) keys = keys.slice(keys.length - MAX_KEYS);
+    const path = statePath(env);
+    await writeFile(path, keys.join('\n') + '\n', { mode: FILE_MODE });
+    await chmod(path, FILE_MODE).catch(() => {});
+    return true;
+  } catch {
+    return false; // couldn't persist → runHook will NOT deny (avoids a loop)
+  }
+}

--- a/src/repoConfig.test.ts
+++ b/src/repoConfig.test.ts
@@ -1,0 +1,39 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { isSkipped, isDisabled, SKIP_TOKEN } from './repoConfig.js';
+
+const pexec = promisify(execFile);
+
+test('isSkipped: the token in the command opts out', () => {
+  assert.equal(isSkipped(`git commit -m "wip ${SKIP_TOKEN}"`, {}), true);
+  assert.equal(isSkipped('gh pr create --title T', {}), false);
+});
+
+test('isSkipped: the env flag opts out (any truthy form)', () => {
+  assert.equal(isSkipped('gh pr create', { ADD_REASONING_TO_PRS_SKIP: '1' }), true);
+  assert.equal(isSkipped('gh pr create', { ADD_REASONING_TO_PRS_SKIP: 'true' }), true);
+  assert.equal(isSkipped('gh pr create', { ADD_REASONING_TO_PRS_SKIP: '0' }), false);
+  assert.equal(isSkipped('gh pr create', {}), false);
+});
+
+test('isDisabled: the global env flag disables', async () => {
+  assert.equal(await isDisabled('/nonexistent', { ADD_REASONING_TO_PRS_DISABLE: '1' }), true);
+});
+
+test('isDisabled: reads the per-repo git config, defaulting to enabled', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'arp-cfg-'));
+  await pexec('git', ['init', '-q'], { cwd: dir });
+  // Unset → not disabled.
+  assert.equal(await isDisabled(dir, {}), false);
+  // Set the per-repo off switch → disabled.
+  await pexec('git', ['config', 'add-reasoning-to-prs.disabled', 'true'], { cwd: dir });
+  assert.equal(await isDisabled(dir, {}), true);
+  // Explicit false → re-enabled.
+  await pexec('git', ['config', 'add-reasoning-to-prs.disabled', 'false'], { cwd: dir });
+  assert.equal(await isDisabled(dir, {}), false);
+});

--- a/src/repoConfig.ts
+++ b/src/repoConfig.ts
@@ -1,0 +1,54 @@
+// repoConfig.ts — the trigger controls: a per-repo OFF switch and a per-invocation SKIP.
+//
+// Installing the hook is the opt-in (auto-on once installed), so these are the escape
+// hatches:
+//   • OFF (per repo, sticky):  `git config add-reasoning-to-prs.disabled true`
+//                              or ADD_REASONING_TO_PRS_DISABLE=1 (global, via the env).
+//   • SKIP (one command):      include the token [skip-why] anywhere in the command
+//                              (e.g. in the commit message, PR body, or a trailing
+//                              `# [skip-why]`), or set ADD_REASONING_TO_PRS_SKIP=1.
+//
+// Note on the env flags: a hook runs in the environment Claude Code launched with, so
+// these env vars work as a session/global toggle (set them before starting Claude Code).
+// They are NOT read from a `VAR=… git commit` prefix on the command — that prefix scopes
+// to the git process, not this hook. The in-command [skip-why] token is the true
+// per-invocation escape hatch.
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const pexec = promisify(execFile);
+
+/** The per-invocation skip token to drop into a command to opt out just this once. */
+export const SKIP_TOKEN = '[skip-why]';
+
+function envTrue(v: string | undefined): boolean {
+  if (typeof v !== 'string') return false;
+  const s = v.trim().toLowerCase();
+  return s === '1' || s === 'true' || s === 'yes' || s === 'on';
+}
+
+/** True if the hook is disabled for this repo (git config) or globally (env var). */
+export async function isDisabled(
+  cwd: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<boolean> {
+  if (envTrue(env.ADD_REASONING_TO_PRS_DISABLE)) return true;
+  try {
+    const { stdout } = await pexec(
+      'git',
+      ['config', '--get', 'add-reasoning-to-prs.disabled'],
+      { cwd, timeout: 3000, windowsHide: true },
+    );
+    return envTrue(stdout);
+  } catch {
+    // git exits non-zero when the key is unset (and on any error) → not disabled.
+    return false;
+  }
+}
+
+/** True if THIS command opts out — the skip token is present, or the env flag is set. */
+export function isSkipped(command: string, env: NodeJS.ProcessEnv = process.env): boolean {
+  if (envTrue(env.ADD_REASONING_TO_PRS_SKIP)) return true;
+  return typeof command === 'string' && command.includes(SKIP_TOKEN);
+}


### PR DESCRIPTION
## Surface routing + trigger controls (off-switch, skip, anti-loop cap)

Completes the routing and adds the controls — including the **anti-loop deny cap** flagged `[medium]` on the harness PR.

### Surface routing (`git.ts`)
`branchInfo()` resolves the current branch name **and** whether it's the default in one git pass. The name feeds the deny-cap key; the default-ness feeds routing:
- `gh pr create` → the **PR body**.
- `git commit` on the **default** branch → the **commit message** (the direct-push / rescue-to-main surface).
- `git commit` on a **feature** branch → deferred (no-op; it belongs to the eventual PR).

### Trigger controls (`repoConfig.ts`)
Installing the hook is the opt-in (auto-on), so these are the escape hatches:
- **Per-repo OFF switch:** `git config add-reasoning-to-prs.disabled true` (local, uncommitted), or `ADD_REASONING_TO_PRS_DISABLE=1` globally.
- **Per-invocation SKIP:** a `[skip-why]` token anywhere in the command (the reliable per-command escape hatch, since a hook can't see a `VAR=… git commit` prefix), or `ADD_REASONING_TO_PRS_SKIP=1` in the session environment.

### Anti-loop deny cap (`promptState.ts`)
Deny **at most once** per `(session, surface, branch)`. If the model concludes the session had nothing worth recording and re-runs the command with no block, the second time is allowed instead of denied — so the empty/no-decision path can't loop. **Loop-safe by construction:** we deny only after the cap is persisted, and any doubt about the state file resolves to "already prompted" (→ allow), never to a re-deny. Keying on **branch** means two distinct PRs (distinct branches) in one session are each still prompted.

### Accepted v1 gaps (documented)
- A browser-opened feature-branch PR (no `gh pr create`) isn't intercepted.
- Multiple **direct commits to the default branch within one session** are prompted once (same `session:commit:branch` key); ordinary feature→PR flows are unaffected.

### Done when
- **PR + direct-push each write the right surface** — verified (PR body vs commit message), including feature-branch deferral.
- **Off-switch + skip honored** — verified end-to-end through the built bundle against a real repo (git-config disable, `[skip-why]` token, env flags), plus the cap breaking the loop and a new branch still prompting.

### Testing
- `npm run typecheck` clean; `npm test` 44/44.
