### PR TITLE
Local self-critique (never-fabricate) pass

### DIFF
--- a/dist-bundle/add-reasoning-to-prs.js
+++ b/dist-bundle/add-reasoning-to-prs.js
@@ -308,13 +308,17 @@ Compose the block ONLY from what you actually decided in THIS session \u2014 nev
 Rules:
 - Forward-only: capture what the diff can't show \u2014 the why, and the risks knowingly taken. Never summarize the changes.
 - Grounded: every line must trace to real deliberation in this session. Cut anything padded, generic, or inferred.
-- If the session had no genuine decisions to record, that's fine \u2014 leave it out rather than manufacture filler.
 - Keep it tight: a few lines per section at most.
 - Wrap the block EXACTLY between the two markers below so it is detected and left untouched on later runs:
 
 ${exampleBlock(surface)}
 
-Then re-run your original command with the block included in ${c.where}.`;
+Self-check BEFORE you write \u2014 a quick grounded pass, no tools or network needed:
+- Take each candidate line and name the specific point in THIS session where that decision, assumption, trade-off, or limitation actually came up. If you can't point to one, delete the line.
+- Delete anything that just restates the diff ("added X", "refactored Y") without a why, and any generic filler ("improves code quality", "various cleanups").
+- Whatever survives is the block. If NOTHING survives, there is no block to add: re-run your original command unchanged, or add ${SKIP_TOKEN} to it to opt out explicitly. Never manufacture filler to fill the template \u2014 an empty block is the correct outcome for a session that didn't deliberate.
+
+Otherwise, re-run your original command with the surviving block included in ${c.where}.`;
 }
 
 // src/hook.ts

--- a/src/critique.test.ts
+++ b/src/critique.test.ts
@@ -1,0 +1,70 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isPadding, scrubLines, scrubPrimitives } from './critique.js';
+
+test('drops padded/filler lines but keeps genuine deliberation (the fixture)', () => {
+  const input = [
+    'Various minor improvements',
+    'Chose polling over webhooks because the vendor exposes no webhook API',
+    'Improved code quality',
+    'Assumed the 30s vendor timeout is stable; revisit if they change it',
+    'N/A',
+    'cleanup',
+  ];
+  const out = scrubLines(input);
+  assert.deepEqual(out, [
+    'Chose polling over webhooks because the vendor exposes no webhook API',
+    'Assumed the 30s vendor timeout is stable; revisit if they change it',
+  ]);
+});
+
+test('a genuine why-line that starts with a change verb is NOT dropped', () => {
+  // The scrub must never confuse "what changed + why" with pure filler.
+  assert.equal(
+    isPadding('Added exponential backoff because the vendor rate-limits aggressively'),
+    false,
+  );
+  assert.equal(isPadding('Refactored the parser to isolate the retry boundary for testability'), false);
+  assert.equal(isPadding('Removed the cache since staleness caused the incident'), false);
+});
+
+test('recognizes unambiguous filler as padding', () => {
+  for (const f of [
+    'various improvements',
+    'minor changes',
+    'improves code quality',
+    'made the code cleaner',
+    'general cleanup',
+    'refactoring',
+    'N/A',
+    'none',
+    'tbd',
+    'No notable decisions',
+    '   ',
+    '- ',
+  ]) {
+    assert.equal(isPadding(f), true, `expected isPadding(${JSON.stringify(f)}) === true`);
+  }
+});
+
+test('de-duplicates (case-insensitive) and strips bullets', () => {
+  assert.deepEqual(scrubLines(['- Chose Postgres', 'chose postgres', 'Chose Redis']), [
+    'Chose Postgres',
+    'Chose Redis',
+  ]);
+});
+
+test('scrubPrimitives cleans every section and leaves empties empty', () => {
+  const out = scrubPrimitives({
+    decisions: ['Picked A because B', 'various improvements'],
+    assumptions: ['none'],
+    tradeoffs: [],
+    limitations: ['Skipped the migration for the follow-up PR'],
+  });
+  assert.deepEqual(out, {
+    decisions: ['Picked A because B'],
+    assumptions: [],
+    tradeoffs: [],
+    limitations: ['Skipped the migration for the follow-up PR'],
+  });
+});

--- a/src/critique.ts
+++ b/src/critique.ts
@@ -1,0 +1,68 @@
+// critique.ts — the LOCAL, deterministic half of the never-fabricate posture.
+//
+// Fabrication is prevented in two $0/local ways (no server, ever):
+//   1. The model's own IN-TURN self-critique — instructed by the injected guidance
+//      (guidance.ts): before writing, it re-checks each line against what it actually
+//      decided this session and drops anything it can't ground. That's the SEMANTIC pass;
+//      only the model can judge "did this really come up?".
+//   2. This mechanical scrub — a deterministic filter that drops UNAMBIGUOUS filler and
+//      duplicate lines. It deliberately does NOT try to judge grounding or why-vs-what
+//      (a syntactic rule can't tell "Added retries" from "Added retries because the API
+//      is flaky" — dropping the latter would destroy a real decision). It only removes
+//      lines that are content-free no matter the context.
+//
+// The scrub is what keeps the multi-session scratchpad clean before its accumulated
+// primitives are rendered back into the guidance.
+
+import type { WhyPrimitives } from './template.js';
+
+// Whole-line filler: matched anchored (^…$) against the de-bulleted, trimmed line, so a
+// genuine line that merely CONTAINS one of these words is never dropped.
+const FILLER_PATTERNS: RegExp[] = [
+  /^(n\/?a|none|nil|tbd|todo|-{1,}|\.{1,})$/i,
+  // One or more filler adjectives ("various", "minor", …) + a filler noun, whole-line.
+  /^((various|minor|misc\.?|miscellaneous|small|some|general|other)\s+)+(changes?|improvements?|updates?|fixes|tweaks|edits|stuff|things)\.?$/i,
+  /^(general\s+|misc\.?\s+)?clean(ed)?[\s-]*up\.?$/i,
+  /^improve[sd]?\s+(the\s+)?code\s+quality\.?$/i,
+  /^(made|make)\s+(the\s+)?code\s+(better|cleaner|nicer)\.?$/i,
+  /^(better|cleaner|improved)\s+code\.?$/i,
+  /^(code\s+)?(quality|cleanup|refactor(ing)?|polish)\.?$/i,
+  /^no\s+(notable\s+)?(decisions?|changes?|deliberation)\.?$/i,
+];
+
+/** Strip a leading markdown bullet and surrounding whitespace. */
+function debullet(line: string): string {
+  return line.replace(/^\s*[-*]\s*/, '').trim();
+}
+
+/** True if a line is content-free filler (or empty) that should be dropped. */
+export function isPadding(line: string): boolean {
+  const t = debullet(line);
+  if (t.length === 0) return true;
+  return FILLER_PATTERNS.some((re) => re.test(t));
+}
+
+/** Drop filler + exact-duplicate lines, preserving order and original wording. */
+export function scrubLines(lines: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of Array.isArray(lines) ? lines : []) {
+    if (typeof raw !== 'string') continue;
+    if (isPadding(raw)) continue;
+    const key = debullet(raw).toLowerCase();
+    if (seen.has(key)) continue; // de-duplicate (case-insensitive)
+    seen.add(key);
+    out.push(debullet(raw));
+  }
+  return out;
+}
+
+/** Scrub every primitive's lines. Empty sections simply become empty arrays. */
+export function scrubPrimitives(p: WhyPrimitives): WhyPrimitives {
+  return {
+    decisions: scrubLines(p.decisions ?? []),
+    assumptions: scrubLines(p.assumptions ?? []),
+    tradeoffs: scrubLines(p.tradeoffs ?? []),
+    limitations: scrubLines(p.limitations ?? []),
+  };
+}

--- a/src/guidance.test.ts
+++ b/src/guidance.test.ts
@@ -1,0 +1,33 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildGuidance } from './guidance.js';
+import { SKIP_TOKEN } from './repoConfig.js';
+import { PR_MARKER_OPEN, COMMIT_MARKER_OPEN } from './marker.js';
+
+test('guidance is surface-aware and lists all four primitives', () => {
+  const pr = buildGuidance('pr');
+  assert.match(pr, /pull request description/i);
+  assert.ok(pr.includes(PR_MARKER_OPEN));
+  for (const p of ['Decisions', 'Assumptions', 'Trade-offs', 'Limitations']) {
+    assert.ok(pr.includes(p), `PR guidance should mention ${p}`);
+  }
+
+  const commit = buildGuidance('commit');
+  assert.match(commit, /commit message body/i);
+  assert.ok(commit.includes(COMMIT_MARKER_OPEN));
+});
+
+test('guidance includes an explicit before-writing self-critique pass', () => {
+  const g = buildGuidance('pr');
+  assert.match(g, /self-check/i);
+  assert.match(g, /name the specific point in THIS session/i);
+  assert.match(g, /delete the line/i);
+});
+
+test('guidance makes the leave-empty path explicit (no manufactured filler)', () => {
+  const g = buildGuidance('commit');
+  assert.match(g, /if nothing survives/i);
+  assert.match(g, /re-run your original command unchanged/i);
+  assert.ok(g.includes(SKIP_TOKEN), 'guidance should surface the explicit skip escape hatch');
+  assert.match(g, /never manufacture filler/i);
+});

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -8,6 +8,7 @@
 // primitives; the model includes only the sections that genuinely apply.
 
 import { renderBlock, type Surface } from './template.js';
+import { SKIP_TOKEN } from './repoConfig.js';
 
 // Re-export so existing importers (hook.ts) keep a single import site for Surface.
 export type { Surface } from './template.js';
@@ -60,11 +61,15 @@ Compose the block ONLY from what you actually decided in THIS session — never 
 Rules:
 - Forward-only: capture what the diff can't show — the why, and the risks knowingly taken. Never summarize the changes.
 - Grounded: every line must trace to real deliberation in this session. Cut anything padded, generic, or inferred.
-- If the session had no genuine decisions to record, that's fine — leave it out rather than manufacture filler.
 - Keep it tight: a few lines per section at most.
 - Wrap the block EXACTLY between the two markers below so it is detected and left untouched on later runs:
 
 ${exampleBlock(surface)}
 
-Then re-run your original command with the block included in ${c.where}.`;
+Self-check BEFORE you write — a quick grounded pass, no tools or network needed:
+- Take each candidate line and name the specific point in THIS session where that decision, assumption, trade-off, or limitation actually came up. If you can't point to one, delete the line.
+- Delete anything that just restates the diff ("added X", "refactored Y") without a why, and any generic filler ("improves code quality", "various cleanups").
+- Whatever survives is the block. If NOTHING survives, there is no block to add: re-run your original command unchanged, or add ${SKIP_TOKEN} to it to opt out explicitly. Never manufacture filler to fill the template — an empty block is the correct outcome for a session that didn't deliberate.
+
+Otherwise, re-run your original command with the surviving block included in ${c.where}.`;
 }


### PR DESCRIPTION
## Local self-critique (never-fabricate) pass

Prevents fabrication with two **$0/local** mechanisms — no account, no server, ever.

### 1. In-turn self-critique (`guidance.ts`) — the semantic pass
The injected guidance now includes an explicit **before-writing self-check**:
- For each candidate line, name the specific point in *this* session where that decision/assumption/trade-off/limitation actually came up — if you can't, delete it.
- Delete diff-restatements ("added X", "refactored Y") and generic filler.
- **If nothing survives, that's the right answer:** re-run the command unchanged, or add `[skip-why]` to opt out — never manufacture filler. (This also resolves the leave-empty wording tension flagged on the trigger-controls PR.)

Only the model can judge "did this really come up?", so this semantic grounding lives in the guidance and runs in-turn on the user's own model.

### 2. Deterministic scrub (`critique.ts`) — the mechanical pass
A pure filter that drops **unambiguous** filler ("various minor improvements", "improves code quality", "N/A", "cleanup") and duplicate lines. It deliberately does **not** try to judge grounding or why-vs-what — a syntactic rule can't tell `Added retries` from `Added retries because the API is flaky`, and dropping the latter would destroy a real decision. So a genuine "why" line is **never** dropped. This keeps the multi-session scratchpad clean before its accumulated primitives are rendered back into the guidance (consumed by the multi-session scratchpad).

### Done when
- **Padded/hallucinated line dropped in a fixture; genuine deliberation survives** — verified: `scrubLines` drops the filler and keeps "Chose polling over webhooks because the vendor exposes no webhook API" / "Assumed the 30s vendor timeout is stable…". Verb-prefixed genuine lines (`Added … because …`, `Removed … since …`) are explicitly preserved.

### Testing
- `npm run typecheck` clean; `npm test` 52/52. Verified through the bundle that the deny guidance now carries the self-check step, the `[skip-why]` hatch, and "never manufacture filler."

