### PR TITLE
Multi-session per-branch scratchpad

### DIFF
--- a/dist-bundle/add-reasoning-to-prs.js
+++ b/dist-bundle/add-reasoning-to-prs.js
@@ -88,6 +88,9 @@ async function git(args, cwd) {
 async function currentBranch(cwd) {
   return git(["symbolic-ref", "--quiet", "--short", "HEAD"], cwd);
 }
+async function repoRoot(cwd) {
+  return git(["rev-parse", "--show-toplevel"], cwd);
+}
 async function defaultBranch(cwd) {
   const head = await git(["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd);
   if (head) return head.replace(/^origin\//, "");
@@ -240,6 +243,54 @@ async function markPrompted(key, env = process.env) {
   }
 }
 
+// src/scratch.ts
+import { createHash } from "node:crypto";
+import { homedir as homedir2 } from "node:os";
+import { join as join2 } from "node:path";
+import { readFile as readFile3, writeFile as writeFile2, mkdir as mkdir2, rm, chmod as chmod2 } from "node:fs/promises";
+
+// src/critique.ts
+var FILLER_PATTERNS = [
+  /^(n\/?a|none|nil|tbd|todo|-{1,}|\.{1,})$/i,
+  // One or more filler adjectives ("various", "minor", …) + a filler noun, whole-line.
+  /^((various|minor|misc\.?|miscellaneous|small|some|general|other)\s+)+(changes?|improvements?|updates?|fixes|tweaks|edits|stuff|things)\.?$/i,
+  /^(general\s+|misc\.?\s+)?clean(ed)?[\s-]*up\.?$/i,
+  /^improve[sd]?\s+(the\s+)?code\s+quality\.?$/i,
+  /^(made|make)\s+(the\s+)?code\s+(better|cleaner|nicer)\.?$/i,
+  /^(better|cleaner|improved)\s+code\.?$/i,
+  /^(code\s+)?(quality|cleanup|refactor(ing)?|polish)\.?$/i,
+  /^no\s+(notable\s+)?(decisions?|changes?|deliberation)\.?$/i
+];
+function debullet(line) {
+  return line.replace(/^\s*[-*]\s*/, "").trim();
+}
+function isPadding(line) {
+  const t = debullet(line);
+  if (t.length === 0) return true;
+  return FILLER_PATTERNS.some((re) => re.test(t));
+}
+function scrubLines(lines) {
+  const seen = /* @__PURE__ */ new Set();
+  const out = [];
+  for (const raw of Array.isArray(lines) ? lines : []) {
+    if (typeof raw !== "string") continue;
+    if (isPadding(raw)) continue;
+    const key = debullet(raw).toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(debullet(raw));
+  }
+  return out;
+}
+function scrubPrimitives(p) {
+  return {
+    decisions: scrubLines(p.decisions ?? []),
+    assumptions: scrubLines(p.assumptions ?? []),
+    tradeoffs: scrubLines(p.tradeoffs ?? []),
+    limitations: scrubLines(p.limitations ?? [])
+  };
+}
+
 // src/template.ts
 var PRIMITIVES = ["decisions", "assumptions", "tradeoffs", "limitations"];
 var HEADINGS = {
@@ -275,6 +326,68 @@ function renderBlock(surface, p) {
   return lines.join("\n");
 }
 
+// src/scratch.ts
+var DIR_MODE2 = 448;
+var FILE_MODE2 = 384;
+function scratchDir(env = process.env) {
+  const override = env.ADD_REASONING_TO_PRS_STATE_DIR;
+  const base = override && override.trim().length > 0 ? override : join2(homedir2(), ".add-reasoning-to-prs");
+  return join2(base, "scratch");
+}
+function scratchPath(repoRoot2, branch, env) {
+  const key = createHash("sha256").update(`${repoRoot2}
+${branch}`).digest("hex").slice(0, 32);
+  return join2(scratchDir(env), `${key}.json`);
+}
+function coercePrimitives(obj) {
+  const out = {};
+  if (!obj || typeof obj !== "object") return out;
+  const rec = obj;
+  for (const key of PRIMITIVES) {
+    const v = rec[key];
+    if (Array.isArray(v)) {
+      const items = v.filter((s) => typeof s === "string");
+      if (items.length) out[key] = items;
+    }
+  }
+  return out;
+}
+function merge(a, b) {
+  const out = {};
+  for (const key of PRIMITIVES) out[key] = [...a[key] ?? [], ...b[key] ?? []];
+  return scrubPrimitives(out);
+}
+async function readScratch(repoRoot2, branch, env = process.env) {
+  try {
+    const raw = await readFile3(scratchPath(repoRoot2, branch, env), "utf8");
+    return scrubPrimitives(coercePrimitives(JSON.parse(raw)));
+  } catch {
+    return {};
+  }
+}
+async function appendScratch(repoRoot2, branch, add, env = process.env) {
+  const merged = merge(await readScratch(repoRoot2, branch, env), add);
+  try {
+    const dir = scratchDir(env);
+    await mkdir2(dir, { recursive: true, mode: DIR_MODE2 });
+    const path = scratchPath(repoRoot2, branch, env);
+    await writeFile2(path, JSON.stringify(merged) + "\n", { mode: FILE_MODE2 });
+    await chmod2(path, FILE_MODE2).catch(() => {
+    });
+  } catch {
+  }
+  return merged;
+}
+async function clearScratch(repoRoot2, branch, env = process.env) {
+  try {
+    await rm(scratchPath(repoRoot2, branch, env), { force: true });
+  } catch {
+  }
+}
+function isScratchEmpty(p) {
+  return isEmptyBlock(p);
+}
+
 // src/guidance.ts
 function surfaceCopy(surface) {
   return surface === "pr" ? {
@@ -294,9 +407,25 @@ function exampleBlock(surface) {
     limitations: placeholder
   });
 }
-function buildGuidance(surface) {
+function renderAccumulated(p) {
+  const lines = [];
+  for (const key of PRIMITIVES) {
+    const items = (p[key] ?? []).filter(Boolean);
+    if (items.length === 0) continue;
+    lines.push(`${HEADINGS[key]}:`);
+    for (const it of items) lines.push(`- ${it}`);
+  }
+  return lines.join("\n");
+}
+function buildGuidance(surface, accumulated) {
   const c = surfaceCopy(surface);
-  return `add-reasoning-to-prs: before ${c.moment}, add a short, forward-only "why" block to ${c.where}, then re-run the command.
+  const earlier = accumulated && !isEmptyBlock(accumulated) ? `
+
+Earlier work on this branch (possibly a different session) already recorded these \u2014 fold the still-relevant points into the block instead of pasting them, and drop anything now stale:
+
+${renderAccumulated(accumulated)}
+` : "";
+  return `add-reasoning-to-prs: before ${c.moment}, add a short, forward-only "why" block to ${c.where}, then re-run the command.${earlier}
 
 Compose the block ONLY from what you actually decided in THIS session \u2014 never invent. Include only the sections that genuinely apply, and drop any that don't:
 
@@ -320,10 +449,17 @@ Self-check BEFORE you write \u2014 a quick grounded pass, no tools or network ne
 
 Otherwise, re-run your original command with the surviving block included in ${c.where}.`;
 }
+function buildScratchNudge() {
+  return `add-reasoning-to-prs: you're committing on a feature branch, so this commit isn't touched. If this chunk of work involved a notable decision, assumption, trade-off, or limitation, bank it now \u2014 the eventual PR's why-block will fold it in, even if a different session opens the PR:
+
+  add-reasoning-to-prs scratch add --json '{"decisions":["..."],"tradeoffs":["..."]}'
+
+It's 100% local (nothing is committed) and stores only the why, never code. Skip it if there was nothing notable this time.`;
+}
 
 // src/hook.ts
-function deny(surface) {
-  const guidance = buildGuidance(surface);
+function deny(surface, accumulated) {
+  const guidance = buildGuidance(surface, accumulated);
   return {
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
@@ -335,6 +471,9 @@ function deny(surface) {
       additionalContext: guidance
     }
   };
+}
+function nudge(context) {
+  return { hookSpecificOutput: { hookEventName: "PreToolUse", additionalContext: context } };
 }
 async function runHook(rawStdin, deps = {}) {
   const env = deps.env ?? process.env;
@@ -354,6 +493,7 @@ async function runHook(rawStdin, deps = {}) {
     if (kind === "other") return {};
     if (isSkipped(command, env)) return {};
     const cwd = typeof rec.cwd === "string" && rec.cwd ? rec.cwd : deps.cwd ?? process.cwd();
+    const sessionId = typeof rec.session_id === "string" ? rec.session_id : void 0;
     if (hasMarker(command)) return {};
     const bodyFilePath = extractBodyFilePath(command);
     if (bodyFilePath && hasMarker(await readBodyFile(bodyFilePath, cwd))) return {};
@@ -366,17 +506,79 @@ async function runHook(rawStdin, deps = {}) {
     if (kind === "gh-pr-create") {
       surface = "pr";
     } else {
-      if (!info.isDefault) return {};
+      if (!info.isDefault) {
+        if (info.current) {
+          const nudgeKey = promptKey(sessionId, "scratch-nudge", info.current);
+          if (!await hasPrompted(nudgeKey, env) && await markPrompted(nudgeKey, env)) {
+            return nudge(buildScratchNudge());
+          }
+        }
+        return {};
+      }
       surface = "commit";
     }
-    const sessionId = typeof rec.session_id === "string" ? rec.session_id : void 0;
     const key = promptKey(sessionId, surface, info.current);
     if (await hasPrompted(key, env)) return {};
     if (!await markPrompted(key, env)) return {};
-    return deny(surface);
+    let accumulated;
+    if (surface === "pr" && info.current) {
+      const root = await (deps.repoRootImpl ?? repoRoot)(cwd).catch(() => null);
+      if (root) {
+        const scratch = await readScratch(root, info.current, env);
+        if (!isScratchEmpty(scratch)) accumulated = scratch;
+        await clearScratch(root, info.current, env);
+      }
+    }
+    return deny(surface, accumulated);
   } catch {
     return {};
   }
+}
+
+// src/scratchCommand.ts
+function getFlag(args, name) {
+  const idx = args.indexOf(name);
+  if (idx >= 0 && idx + 1 < args.length) return args[idx + 1];
+  const prefix = `${name}=`;
+  const eq = args.find((a) => a.startsWith(prefix));
+  return eq ? eq.slice(prefix.length) : void 0;
+}
+async function runScratch(args) {
+  const sub = args[0];
+  const cwd = process.cwd();
+  const [root, branch] = await Promise.all([repoRoot(cwd), currentBranch(cwd)]);
+  if (sub === "add") {
+    if (!root || !branch) {
+      process.stderr.write("add-reasoning-to-prs: not in a git repo (or detached HEAD) \u2014 nothing banked.\n");
+      return 0;
+    }
+    const raw = getFlag(args, "--json") ?? await readRawStdin();
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      process.stderr.write(
+        `add-reasoning-to-prs: scratch add expects JSON \u2014 --json '{"decisions":["..."]}' or piped on stdin.
+`
+      );
+      return 0;
+    }
+    const merged = await appendScratch(root, branch, coercePrimitives(parsed));
+    process.stdout.write(JSON.stringify(merged) + "\n");
+    return 0;
+  }
+  if (sub === "show") {
+    const scratch = root && branch ? await readScratch(root, branch) : {};
+    process.stdout.write(JSON.stringify(scratch) + "\n");
+    return 0;
+  }
+  if (sub === "clear") {
+    if (root && branch) await clearScratch(root, branch);
+    process.stdout.write("cleared\n");
+    return 0;
+  }
+  process.stderr.write("usage: add-reasoning-to-prs scratch <add|show|clear>\n");
+  return 0;
 }
 
 // src/cli.ts
@@ -407,6 +609,9 @@ async function run(argv) {
     const out = await runHook(raw);
     process.stdout.write(JSON.stringify(out));
     return 0;
+  }
+  if (cmd === "scratch") {
+    return runScratch(args.slice(1));
   }
   process.stdout.write(help());
   return 0;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@
 import { VERSION } from './version.js';
 import { readRawStdin } from './stdin.js';
 import { runHook } from './hook.js';
+import { runScratch } from './scratchCommand.js';
 
 export function help(): string {
   return `add-reasoning-to-prs ${VERSION}
@@ -49,6 +50,12 @@ export async function run(argv: string[]): Promise<number> {
     const out = await runHook(raw);
     process.stdout.write(JSON.stringify(out));
     return 0;
+  }
+
+  // Bank / show / clear the per-branch scratchpad (used to carry the "why" across
+  // sessions on a branch until the PR is opened).
+  if (cmd === 'scratch') {
+    return runScratch(args.slice(1));
   }
 
   // Default (no args) and explicit help both print usage.

--- a/src/git.ts
+++ b/src/git.ts
@@ -25,6 +25,12 @@ export async function currentBranch(cwd: string): Promise<string | null> {
   return git(['symbolic-ref', '--quiet', '--short', 'HEAD'], cwd);
 }
 
+/** The absolute repo root (git toplevel), or null on error / non-repo. Used to key the
+ * per-branch scratchpad so it's scoped to this repo (and distinct across worktrees). */
+export async function repoRoot(cwd: string): Promise<string | null> {
+  return git(['rev-parse', '--show-toplevel'], cwd);
+}
+
 /**
  * The repo's default branch name, best-effort and OFFLINE:
  *   1. the local `origin/HEAD` symbolic ref (set by clone / `git remote set-head`), else

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -7,7 +7,14 @@
 // aware (PR body vs commit message use different delimiters) and enumerates all four
 // primitives; the model includes only the sections that genuinely apply.
 
-import { renderBlock, type Surface } from './template.js';
+import {
+  renderBlock,
+  HEADINGS,
+  PRIMITIVES,
+  isEmptyBlock,
+  type Surface,
+  type WhyPrimitives,
+} from './template.js';
 import { SKIP_TOKEN } from './repoConfig.js';
 
 // Re-export so existing importers (hook.ts) keep a single import site for Surface.
@@ -42,14 +49,34 @@ function exampleBlock(surface: Surface): string {
   });
 }
 
+/** Render accumulated (earlier-session) primitives as a plain, readable list. */
+function renderAccumulated(p: WhyPrimitives): string {
+  const lines: string[] = [];
+  for (const key of PRIMITIVES) {
+    const items = (p[key] ?? []).filter(Boolean);
+    if (items.length === 0) continue;
+    lines.push(`${HEADINGS[key]}:`);
+    for (const it of items) lines.push(`- ${it}`);
+  }
+  return lines.join('\n');
+}
+
 /**
  * Build the guidance for a surface. The SAME text is used for both the
  * `permissionDecisionReason` (the reliable floor, honored on every Claude Code version)
  * and `additionalContext` (a progressive enhancement), so the model always sees it.
+ *
+ * When `accumulated` primitives are supplied (banked earlier on this branch, possibly by
+ * a different session), they're surfaced so the block can cover the WHOLE branch — the
+ * model folds the still-relevant ones in rather than pasting them verbatim.
  */
-export function buildGuidance(surface: Surface): string {
+export function buildGuidance(surface: Surface, accumulated?: WhyPrimitives): string {
   const c = surfaceCopy(surface);
-  return `add-reasoning-to-prs: before ${c.moment}, add a short, forward-only "why" block to ${c.where}, then re-run the command.
+  const earlier =
+    accumulated && !isEmptyBlock(accumulated)
+      ? `\n\nEarlier work on this branch (possibly a different session) already recorded these — fold the still-relevant points into the block instead of pasting them, and drop anything now stale:\n\n${renderAccumulated(accumulated)}\n`
+      : '';
+  return `add-reasoning-to-prs: before ${c.moment}, add a short, forward-only "why" block to ${c.where}, then re-run the command.${earlier}
 
 Compose the block ONLY from what you actually decided in THIS session — never invent. Include only the sections that genuinely apply, and drop any that don't:
 
@@ -72,4 +99,17 @@ Self-check BEFORE you write — a quick grounded pass, no tools or network neede
 - Whatever survives is the block. If NOTHING survives, there is no block to add: re-run your original command unchanged, or add ${SKIP_TOKEN} to it to opt out explicitly. Never manufacture filler to fill the template — an empty block is the correct outcome for a session that didn't deliberate.
 
 Otherwise, re-run your original command with the surviving block included in ${c.where}.`;
+}
+
+/**
+ * The best-effort nudge injected (as non-blocking additionalContext) on a feature-branch
+ * commit: bank this session's why to the branch scratchpad so the eventual PR — even one
+ * opened by a different session — can cover the whole branch.
+ */
+export function buildScratchNudge(): string {
+  return `add-reasoning-to-prs: you're committing on a feature branch, so this commit isn't touched. If this chunk of work involved a notable decision, assumption, trade-off, or limitation, bank it now — the eventual PR's why-block will fold it in, even if a different session opens the PR:
+
+  add-reasoning-to-prs scratch add --json '{"decisions":["..."],"tradeoffs":["..."]}'
+
+It's 100% local (nothing is committed) and stores only the why, never code. Skip it if there was nothing notable this time.`;
 }

--- a/src/hook.test.ts
+++ b/src/hook.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { runHook, type HookDeps } from './hook.js';
 import { PR_MARKER_OPEN, PR_MARKER_CLOSE } from './marker.js';
+import { appendScratch, readScratch, isScratchEmpty } from './scratch.js';
 
 /** Build a PreToolUse/Bash payload string. */
 function payload(command: string, extra: Record<string, unknown> = {}): string {
@@ -41,6 +42,7 @@ test('gh pr create without a block → deny with guidance (both channels)', asyn
   assert.ok(hs, 'expected a hookSpecificOutput');
   assert.equal(hs.hookEventName, 'PreToolUse');
   assert.equal(hs.permissionDecision, 'deny');
+  assert.ok(hs.permissionDecisionReason);
   assert.match(hs.permissionDecisionReason, /forward-only/i);
   assert.match(hs.permissionDecisionReason, /pull request description/i);
   assert.equal(hs.additionalContext, hs.permissionDecisionReason);
@@ -70,11 +72,13 @@ test('still denies when the --body-file exists but has NO block', async () => {
 test('git commit on the DEFAULT branch → deny with the commit-surface guidance', async () => {
   const out = await runHook(payload('git commit -m "wip"'), await mkDeps(AS_DEFAULT));
   assert.equal(out.hookSpecificOutput?.permissionDecision, 'deny');
-  assert.match(out.hookSpecificOutput!.permissionDecisionReason, /commit message body/i);
+  assert.match(out.hookSpecificOutput?.permissionDecisionReason ?? '', /commit message body/i);
 });
 
-test('git commit on a FEATURE branch → no-op (defers to PR-create)', async () => {
-  assert.deepEqual(await runHook(payload('git commit -m "wip"'), await mkDeps(AS_FEATURE)), {});
+test('git commit on a FEATURE branch never denies (defers to PR-create)', async () => {
+  // It may emit a non-blocking bank nudge, but it must never deny the commit.
+  const out = await runHook(payload('git commit -m "wip"'), await mkDeps(AS_FEATURE));
+  assert.notEqual(out.hookSpecificOutput?.permissionDecision, 'deny');
 });
 
 test('non-matching command / non-Bash tool → no-op', async () => {
@@ -138,6 +142,40 @@ test('deny cap: the same operation is denied at most once (empty-retry does not 
   // The model finds nothing to add and re-runs the SAME command with no block:
   const second = await runHook(payload('gh pr create --title T'), deps);
   assert.deepEqual(second, {}, 'second time is capped → allow (no loop)');
+});
+
+// --- multi-session scratchpad -----------------------------------------------------
+
+test('feature-branch commit: nudges once per session to bank the why (non-blocking)', async () => {
+  const deps = await mkDeps(AS_FEATURE);
+  const first = await runHook(payload('git commit -m wip'), deps);
+  // A non-blocking context nudge — additionalContext but NO permissionDecision.
+  assert.equal(first.hookSpecificOutput?.permissionDecision, undefined);
+  assert.match(first.hookSpecificOutput?.additionalContext ?? '', /scratch add/);
+  // Second commit in the same session: already nudged → silent no-op.
+  const second = await runHook(payload('git commit -m more'), deps);
+  assert.deepEqual(second, {});
+});
+
+test('PR-create folds the accumulated scratchpad into the guidance, then clears it', async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), 'arp-state-'));
+  const env = { ADD_REASONING_TO_PRS_STATE_DIR: stateDir };
+  const root = '/repo';
+  const branch = 'feat/multi';
+  // An earlier session banked a decision:
+  await appendScratch(root, branch, { decisions: ['Chose polling because no webhook API'] }, env);
+
+  const out = await runHook(payload('gh pr create --title T', { session_id: 'sessB' }), {
+    branchInfoImpl: async () => ({ current: branch, isDefault: false }),
+    repoRootImpl: async () => root,
+    isDisabledImpl: async () => false,
+    env,
+  });
+  // The block-to-be covers the whole branch: the earlier decision is surfaced.
+  assert.match(out.hookSpecificOutput!.permissionDecisionReason!, /Chose polling because no webhook API/);
+  assert.match(out.hookSpecificOutput!.permissionDecisionReason!, /Earlier work on this branch/i);
+  // And the scratchpad is consumed (cleared) at PR-create.
+  assert.equal(isScratchEmpty(await readScratch(root, branch, env)), true);
 });
 
 test('deny cap: a different branch (distinct PR) in the same session is still prompted', async () => {

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -3,29 +3,32 @@
 // Claude Code runs this synchronously BEFORE a Bash tool call and reads its stdout for a
 // decision. When the command is a `git commit` (on the default branch) or a `gh pr create`
 // that lacks a why-block — and the hook is enabled and not skipped — we DENY once with a
-// reason + injected guidance, so the live model composes the block and re-runs. Everything
-// else → an empty `{}` (no injection, the tool proceeds).
+// reason + injected guidance, so the live model composes the block and re-runs. On a
+// feature-branch commit we don't block, but we nudge (once) to bank the session's why to
+// the branch scratchpad. Everything else → an empty `{}` (no injection, the tool proceeds).
 //
 // NON-NEGOTIABLE POSTURE (fail-open): this must NEVER block or delay the user's git op.
-// Every failure mode — unparseable payload, missing git, unwritable state, a throw
-// anywhere — resolves to `{}` and exit 0. It never exits 2, never hard-blocks, and (via
-// the deny cap) never denies the same operation twice.
+// Every failure mode resolves to `{}` and exit 0. It never exits 2, never hard-blocks, and
+// (via the deny cap) never denies the same operation twice.
 
 import { classifyCommand } from './command.js';
 import { hasMarker } from './marker.js';
-import { branchInfo } from './git.js';
+import { branchInfo, repoRoot } from './git.js';
 import { extractBodyFilePath, readBodyFile } from './bodyFile.js';
 import { isDisabled, isSkipped } from './repoConfig.js';
 import { hasPrompted, markPrompted, promptKey } from './promptState.js';
-import { buildGuidance, type Surface } from './guidance.js';
+import { readScratch, clearScratch, isScratchEmpty } from './scratch.js';
+import { buildGuidance, buildScratchNudge, type Surface } from './guidance.js';
+import type { WhyPrimitives } from './template.js';
 
-/** The PreToolUse hook output. `{}` = no injection (fail-open); otherwise a deny. */
+/** The PreToolUse hook output. `{}` = no injection (fail-open); otherwise a deny or a
+ * non-blocking context nudge. */
 export interface PreToolUseHookOutput {
   hookSpecificOutput?: {
     hookEventName: 'PreToolUse';
-    permissionDecision: 'deny';
-    permissionDecisionReason: string;
-    additionalContext: string;
+    permissionDecision?: 'deny';
+    permissionDecisionReason?: string;
+    additionalContext?: string;
   };
 }
 
@@ -36,12 +39,14 @@ export interface HookDeps {
   env?: NodeJS.ProcessEnv;
   /** Test seam: current-branch + default-ness. Defaults to git.branchInfo. */
   branchInfoImpl?: (cwd: string) => Promise<{ current: string | null; isDefault: boolean }>;
+  /** Test seam: repo root (for the scratchpad key). Defaults to git.repoRoot. */
+  repoRootImpl?: (cwd: string) => Promise<string | null>;
   /** Test seam: the per-repo/global off switch. Defaults to repoConfig.isDisabled. */
   isDisabledImpl?: (cwd: string, env: NodeJS.ProcessEnv) => Promise<boolean>;
 }
 
-function deny(surface: Surface): PreToolUseHookOutput {
-  const guidance = buildGuidance(surface);
+function deny(surface: Surface, accumulated?: WhyPrimitives): PreToolUseHookOutput {
+  const guidance = buildGuidance(surface, accumulated);
   return {
     hookSpecificOutput: {
       hookEventName: 'PreToolUse',
@@ -53,6 +58,11 @@ function deny(surface: Surface): PreToolUseHookOutput {
       additionalContext: guidance,
     },
   };
+}
+
+/** A non-blocking context injection (no permissionDecision → the tool proceeds). */
+function nudge(context: string): PreToolUseHookOutput {
+  return { hookSpecificOutput: { hookEventName: 'PreToolUse', additionalContext: context } };
 }
 
 /**
@@ -84,10 +94,11 @@ export async function runHook(rawStdin: string, deps: HookDeps = {}): Promise<Pr
     if (kind === 'other') return {};
 
     // Per-invocation skip (a [skip-why] token in the command, or the env flag). Cheap
-    // string check — do it before any git/filesystem work.
+    // string check — before any git/filesystem work.
     if (isSkipped(command, env)) return {};
 
     const cwd = typeof rec.cwd === 'string' && rec.cwd ? rec.cwd : (deps.cwd ?? process.cwd());
+    const sessionId = typeof rec.session_id === 'string' ? rec.session_id : undefined;
 
     // Idempotency: the command already carries a block (the model's own retry, or a
     // hand-written one), inline or in a --body-file/-F/--file → leave it alone.
@@ -98,30 +109,52 @@ export async function runHook(rawStdin: string, deps: HookDeps = {}): Promise<Pr
     // Per-repo / global off switch.
     if (await (deps.isDisabledImpl ?? isDisabled)(cwd, env)) return {};
 
-    // Surface routing (one git query for both the name and default-ness):
-    // `gh pr create` → the PR body. A `git commit` gets a block only on the DEFAULT branch
-    // (the direct-push surface); a feature-branch commit defers to PR-create.
+    // One git query for both the branch name and default-ness.
     const info = await (deps.branchInfoImpl ?? branchInfo)(cwd).catch(() => ({
       current: null as string | null,
       isDefault: false,
     }));
+
+    // Surface routing.
     let surface: Surface;
     if (kind === 'gh-pr-create') {
       surface = 'pr';
     } else {
-      if (!info.isDefault) return {};
-      surface = 'commit';
+      // `git commit` on a FEATURE branch: don't block it, but nudge ONCE per session+branch
+      // to bank this session's why to the scratchpad for the eventual PR. Only when we
+      // actually know the branch (an unknown/detached HEAD stays a silent no-op).
+      if (!info.isDefault) {
+        if (info.current) {
+          const nudgeKey = promptKey(sessionId, 'scratch-nudge', info.current);
+          if (!(await hasPrompted(nudgeKey, env)) && (await markPrompted(nudgeKey, env))) {
+            return nudge(buildScratchNudge());
+          }
+        }
+        return {};
+      }
+      surface = 'commit'; // direct commit on the default branch
     }
 
     // Anti-loop DENY CAP: deny at most once per (session, surface, branch). We deny ONLY
     // after recording the cap; if we've already prompted, or can't persist the cap, we
-    // stand down — so the same operation is never denied twice (see promptState.ts).
-    const sessionId = typeof rec.session_id === 'string' ? rec.session_id : undefined;
+    // stand down — so the same operation is never denied twice.
     const key = promptKey(sessionId, surface, info.current);
     if (await hasPrompted(key, env)) return {};
     if (!(await markPrompted(key, env))) return {};
 
-    return deny(surface);
+    // At PR-create, READ + CLEAR the branch scratchpad so the block covers the whole
+    // branch (accumulated across earlier sessions). Only the PR surface accumulates.
+    let accumulated: WhyPrimitives | undefined;
+    if (surface === 'pr' && info.current) {
+      const root = await (deps.repoRootImpl ?? repoRoot)(cwd).catch(() => null);
+      if (root) {
+        const scratch = await readScratch(root, info.current, env);
+        if (!isScratchEmpty(scratch)) accumulated = scratch;
+        await clearScratch(root, info.current, env);
+      }
+    }
+
+    return deny(surface, accumulated);
   } catch {
     return {}; // belt-and-braces: any failure → no injection, the git op proceeds
   }

--- a/src/scratch.test.ts
+++ b/src/scratch.test.ts
@@ -1,0 +1,64 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  appendScratch,
+  readScratch,
+  clearScratch,
+  coercePrimitives,
+  isScratchEmpty,
+} from './scratch.js';
+
+async function env(): Promise<NodeJS.ProcessEnv> {
+  return { ADD_REASONING_TO_PRS_STATE_DIR: await mkdtemp(join(tmpdir(), 'arp-scratch-')) };
+}
+
+test('accumulates why across two sessions on the same branch (deduped, scrubbed)', async () => {
+  const e = await env();
+  const root = '/repo';
+  const branch = 'feat/x';
+  await appendScratch(root, branch, { decisions: ['Chose Postgres for the JSONB support'] }, e);
+  await appendScratch(
+    root,
+    branch,
+    {
+      decisions: ['Chose Postgres for the JSONB support', 'Deferred the cache to a follow-up'],
+      tradeoffs: ['various improvements'], // filler → scrubbed out
+    },
+    e,
+  );
+  const acc = await readScratch(root, branch, e);
+  assert.deepEqual(acc.decisions, [
+    'Chose Postgres for the JSONB support',
+    'Deferred the cache to a follow-up',
+  ]);
+  assert.deepEqual(acc.tradeoffs, []);
+});
+
+test('scratchpads are isolated per branch and per repo', async () => {
+  const e = await env();
+  await appendScratch('/repo', 'feat/a', { decisions: ['A'] }, e);
+  assert.deepEqual((await readScratch('/repo', 'feat/a', e)).decisions, ['A']);
+  assert.ok(isScratchEmpty(await readScratch('/repo', 'feat/b', e)));
+  assert.ok(isScratchEmpty(await readScratch('/other', 'feat/a', e)));
+});
+
+test('clearScratch empties the branch scratchpad', async () => {
+  const e = await env();
+  await appendScratch('/repo', 'feat/x', { limitations: ['Skipped the migration'] }, e);
+  assert.equal(isScratchEmpty(await readScratch('/repo', 'feat/x', e)), false);
+  await clearScratch('/repo', 'feat/x', e);
+  assert.equal(isScratchEmpty(await readScratch('/repo', 'feat/x', e)), true);
+});
+
+test('coercePrimitives keeps only the four known keys, as string arrays', () => {
+  const out = coercePrimitives({
+    decisions: ['a', 2, null, 'b'],
+    tradeoffs: 'not-an-array',
+    bogus: ['x'],
+    limitations: ['c'],
+  });
+  assert.deepEqual(out, { decisions: ['a', 'b'], limitations: ['c'] });
+});

--- a/src/scratch.ts
+++ b/src/scratch.ts
@@ -1,0 +1,108 @@
+// scratch.ts — the local, per-branch, multi-session scratchpad.
+//
+// Why-primitives banked during one session (or one commit) on a branch are persisted here
+// so a LATER session — the one that opens the PR, whose model wasn't present for the
+// earlier deliberation — can fold them into the PR's why-block. It accumulates across
+// sessions and is READ + CLEARED at PR-create, so the block covers the whole branch.
+//
+// 100% LOCAL, and stores EXTRACTED WHY ONLY (never source): it lives in the config dir
+// (NOT the repo — nothing to gitignore, nothing to accidentally commit), keyed by repo
+// root + branch. Being per-machine, a fresh machine simply starts empty — the
+// "cross-machine → current-session fallback" the design calls for. Every write is scrubbed
+// (critique.scrubPrimitives) so filler and duplicates never accumulate.
+
+import { createHash } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { readFile, writeFile, mkdir, rm, chmod } from 'node:fs/promises';
+import { scrubPrimitives } from './critique.js';
+import { isEmptyBlock, PRIMITIVES, type WhyPrimitives } from './template.js';
+
+const DIR_MODE = 0o700;
+const FILE_MODE = 0o600;
+
+/** The scratchpad directory (under the shared config dir; env-overridable for tests). */
+export function scratchDir(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.ADD_REASONING_TO_PRS_STATE_DIR;
+  const base = override && override.trim().length > 0 ? override : join(homedir(), '.add-reasoning-to-prs');
+  return join(base, 'scratch');
+}
+
+function scratchPath(repoRoot: string, branch: string, env: NodeJS.ProcessEnv): string {
+  const key = createHash('sha256').update(`${repoRoot}\n${branch}`).digest('hex').slice(0, 32);
+  return join(scratchDir(env), `${key}.json`);
+}
+
+/** Coerce loose JSON into WhyPrimitives — keep only the four known keys as string arrays. */
+export function coercePrimitives(obj: unknown): WhyPrimitives {
+  const out: WhyPrimitives = {};
+  if (!obj || typeof obj !== 'object') return out;
+  const rec = obj as Record<string, unknown>;
+  for (const key of PRIMITIVES) {
+    const v = rec[key];
+    if (Array.isArray(v)) {
+      const items = v.filter((s): s is string => typeof s === 'string');
+      if (items.length) out[key] = items;
+    }
+  }
+  return out;
+}
+
+function merge(a: WhyPrimitives, b: WhyPrimitives): WhyPrimitives {
+  const out: WhyPrimitives = {};
+  for (const key of PRIMITIVES) out[key] = [...(a[key] ?? []), ...(b[key] ?? [])];
+  return scrubPrimitives(out); // scrub the merge → dedupe across sessions, drop filler
+}
+
+/** Read the accumulated (scrubbed) primitives for a branch. Empty object if none. */
+export async function readScratch(
+  repoRoot: string,
+  branch: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<WhyPrimitives> {
+  try {
+    const raw = await readFile(scratchPath(repoRoot, branch, env), 'utf8');
+    return scrubPrimitives(coercePrimitives(JSON.parse(raw)));
+  } catch {
+    return {};
+  }
+}
+
+/** Append primitives to a branch's scratchpad (merged + scrubbed). Returns the merged
+ * result. Best-effort — never throws. */
+export async function appendScratch(
+  repoRoot: string,
+  branch: string,
+  add: WhyPrimitives,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<WhyPrimitives> {
+  const merged = merge(await readScratch(repoRoot, branch, env), add);
+  try {
+    const dir = scratchDir(env);
+    await mkdir(dir, { recursive: true, mode: DIR_MODE });
+    const path = scratchPath(repoRoot, branch, env);
+    await writeFile(path, JSON.stringify(merged) + '\n', { mode: FILE_MODE });
+    await chmod(path, FILE_MODE).catch(() => {});
+  } catch {
+    // best-effort
+  }
+  return merged;
+}
+
+/** Delete a branch's scratchpad (called after PR-create consumes it). Never throws. */
+export async function clearScratch(
+  repoRoot: string,
+  branch: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  try {
+    await rm(scratchPath(repoRoot, branch, env), { force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+/** True if the scratchpad has nothing worth surfacing. */
+export function isScratchEmpty(p: WhyPrimitives): boolean {
+  return isEmptyBlock(p);
+}

--- a/src/scratchCommand.ts
+++ b/src/scratchCommand.ts
@@ -1,0 +1,61 @@
+// scratchCommand.ts — the `scratch` CLI: bank / show / clear the per-branch scratchpad.
+//
+//   add-reasoning-to-prs scratch add --json '{"decisions":["..."],"tradeoffs":["..."]}'
+//   add-reasoning-to-prs scratch show
+//   add-reasoning-to-prs scratch clear
+//
+// `add` also accepts the JSON on stdin. Everything is best-effort: outside a git repo, or
+// on bad input, it prints a note and exits 0 — banking a decision must never fail a flow.
+
+import { repoRoot, currentBranch } from './git.js';
+import { appendScratch, readScratch, clearScratch, coercePrimitives } from './scratch.js';
+import { readRawStdin } from './stdin.js';
+
+function getFlag(args: string[], name: string): string | undefined {
+  const idx = args.indexOf(name);
+  if (idx >= 0 && idx + 1 < args.length) return args[idx + 1];
+  const prefix = `${name}=`;
+  const eq = args.find((a) => a.startsWith(prefix));
+  return eq ? eq.slice(prefix.length) : undefined;
+}
+
+export async function runScratch(args: string[]): Promise<number> {
+  const sub = args[0];
+  const cwd = process.cwd();
+  const [root, branch] = await Promise.all([repoRoot(cwd), currentBranch(cwd)]);
+
+  if (sub === 'add') {
+    if (!root || !branch) {
+      process.stderr.write('add-reasoning-to-prs: not in a git repo (or detached HEAD) — nothing banked.\n');
+      return 0;
+    }
+    const raw = getFlag(args, '--json') ?? (await readRawStdin());
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      process.stderr.write(
+        'add-reasoning-to-prs: scratch add expects JSON — --json \'{"decisions":["..."]}\' or piped on stdin.\n',
+      );
+      return 0;
+    }
+    const merged = await appendScratch(root, branch, coercePrimitives(parsed));
+    process.stdout.write(JSON.stringify(merged) + '\n');
+    return 0;
+  }
+
+  if (sub === 'show') {
+    const scratch = root && branch ? await readScratch(root, branch) : {};
+    process.stdout.write(JSON.stringify(scratch) + '\n');
+    return 0;
+  }
+
+  if (sub === 'clear') {
+    if (root && branch) await clearScratch(root, branch);
+    process.stdout.write('cleared\n');
+    return 0;
+  }
+
+  process.stderr.write('usage: add-reasoning-to-prs scratch <add|show|clear>\n');
+  return 0;
+}


### PR DESCRIPTION
## Multi-session per-branch scratchpad

Carries the "why" across sessions on a branch, so a PR opened by a *later* session — whose model wasn't present for the earlier work — still covers the whole branch.

### Store (`scratch.ts`)
A local store keyed by **repo root + branch**, living in the config dir (**not** the repo — so there's nothing to gitignore and nothing to accidentally commit). It stores **extracted why only, never source**, and every write is scrubbed (dedupe + drop filler via the self-critique scrub). Being per-machine, a fresh machine simply starts empty — the **cross-machine → current-session fallback** the design calls for.

### Populate (`scratch` subcommand + feature-commit nudge)
- `add-reasoning-to-prs scratch add --json '{"decisions":["…"]}'` (or JSON on stdin) banks primitives for the current branch; `scratch show` / `scratch clear` inspect it. Best-effort, always exits 0.
- On a **feature-branch commit**, the hook emits a **non-blocking, once-per-session** nudge (`additionalContext`, no deny) telling the model to bank the session's why via `scratch add`. This auto-populates the scratchpad without ever blocking a commit (feature commits still get no commit-message block).

### Consume (`hook.ts` at PR-create)
When a `gh pr create` is denied, the hook **reads + clears** the branch scratchpad and folds the accumulated primitives into the injected guidance ("Earlier work on this branch … fold the still-relevant points in"), so the PR block spans every session that worked on the branch.

### Done when
- **Two sessions on one branch → block covers both** — verified end-to-end through the bundle: session A banks a decision, session B's PR-create surfaces it in the guidance.
- **Scratchpad cleared post-PR-create** — verified (`scratch show` → `{}` afterward).

### Testing
- `npm run typecheck` clean; `npm test` 58/58 (store round-trip/isolation/scrub + hook nudge + PR-create fold-and-clear).
