### PR TITLE
One-command install + Claude Code plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "add-reasoning-to-prs",
+  "owner": {
+    "name": "Backthread",
+    "url": "https://backthread.dev"
+  },
+  "description": "A Claude Code hook that writes a forward-only \"why\" block into your PR description or commit message.",
+  "plugins": [
+    {
+      "name": "add-reasoning-to-prs",
+      "source": "./",
+      "description": "Writes a forward-only \"why\" block (decisions, trade-offs, assumptions, limitations) into your PR description or commit message at PR-create / direct-push time — composed by your own agent, in-session, with no account and no server round-trip.",
+      "homepage": "https://backthread.dev",
+      "license": "MIT",
+      "keywords": ["claude-code", "pull-request", "commit-message", "decision-log", "documentation"]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -14,9 +14,38 @@ locally — no account, no server round-trip, nothing stored.
 
 ## Install
 
+One command:
+
 ```sh
 npx add-reasoning-to-prs
 ```
+
+This copies the self-contained hook and registers it in your Claude Code settings
+(`~/.claude/settings.json`) as a `PreToolUse` hook — no build step, no dependencies.
+
+Or install the **Claude Code plugin** from the marketplace (recommended — it registers
+the hook globally from the plugin manifest and updates with the plugin, without touching
+your project settings).
+
+## Controls
+
+- **Turn it off for a repo:** `git config add-reasoning-to-prs.disabled true`
+- **Skip a single commit/PR:** put `[skip-why]` anywhere in the command.
+
+## How it works
+
+When you're about to open a PR (`gh pr create`) or land a direct commit on your default
+branch, the hook asks your agent to add a grounded "why" block first, wrapped in an
+invisible marker so it's written once and never duplicated. Feature-branch commits defer
+to the eventual PR; work spread across multiple sessions is carried forward so the PR's
+block covers the whole branch. Nothing is ever fabricated — if a session didn't
+deliberate, no block is added. A hook error never blocks your git command.
+
+---
+
+Your agent writes the "why" into every PR — locally, on your own model, free. Want the
+team view — the why pushed to you and searchable across your whole codebase? See
+[why.backthread.dev](https://why.backthread.dev) and [get.backthread.dev](https://get.backthread.dev).
 
 ## License
 

--- a/dist-bundle/add-reasoning-to-prs.js
+++ b/dist-bundle/add-reasoning-to-prs.js
@@ -581,6 +581,99 @@ async function runScratch(args) {
   return 0;
 }
 
+// src/install.ts
+import { homedir as homedir3 } from "node:os";
+import { join as join3, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readFile as readFile4, writeFile as writeFile3, mkdir as mkdir3, copyFile, chmod as chmod3 } from "node:fs/promises";
+var UPGRADE_CTA = `Your agent now writes the "why" into every PR \u2014 locally, on your own model, free.
+Want the team view \u2014 the why pushed to you and searchable across your whole codebase?
+  \u2192 https://why.backthread.dev   (how it works)
+  \u2192 https://get.backthread.dev   (get the hosted upgrade)`;
+function claudeDir(env) {
+  const override = env.CLAUDE_CONFIG_DIR;
+  return override && override.trim().length > 0 ? override : join3(homedir3(), ".claude");
+}
+function settingsPath(env) {
+  return join3(claudeDir(env), "settings.json");
+}
+function installDir(env) {
+  const override = env.ADD_REASONING_TO_PRS_STATE_DIR;
+  const base = override && override.trim().length > 0 ? override : join3(homedir3(), ".add-reasoning-to-prs");
+  return join3(base, "bin");
+}
+function installedBinPath(env = process.env) {
+  return join3(installDir(env), "add-reasoning-to-prs.js");
+}
+function alreadyInstalled(preToolUse) {
+  if (!Array.isArray(preToolUse)) return false;
+  return preToolUse.some(
+    (entry) => entry && typeof entry === "object" && Array.isArray(entry.hooks) && entry.hooks.some(
+      (h) => h && typeof h === "object" && typeof h.command === "string" && h.command.includes("add-reasoning-to-prs")
+    )
+  );
+}
+async function mergeHook(env, binPath) {
+  const path = settingsPath(env);
+  let raw = null;
+  try {
+    raw = await readFile4(path, "utf8");
+  } catch {
+    raw = null;
+  }
+  let settings = {};
+  if (raw !== null) {
+    try {
+      const parsed = JSON.parse(raw);
+      settings = parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+    } catch {
+      return "skipped-unparseable";
+    }
+  }
+  const hooks = settings.hooks && typeof settings.hooks === "object" ? settings.hooks : {};
+  const preToolUse = Array.isArray(hooks.PreToolUse) ? hooks.PreToolUse : [];
+  if (alreadyInstalled(preToolUse)) return "present";
+  preToolUse.push({
+    matcher: "Bash",
+    hooks: [{ type: "command", command: `node ${JSON.stringify(binPath)} hook` }]
+  });
+  hooks.PreToolUse = preToolUse;
+  settings.hooks = hooks;
+  await mkdir3(dirname(path), { recursive: true });
+  await writeFile3(path, JSON.stringify(settings, null, 2) + "\n");
+  return "added";
+}
+async function runInstall(deps = {}) {
+  const env = deps.env ?? process.env;
+  const log = deps.log ?? ((m) => process.stdout.write(m + "\n"));
+  const source = deps.sourceBinPath ?? fileURLToPath(import.meta.url);
+  try {
+    const dest = installedBinPath(env);
+    await mkdir3(dirname(dest), { recursive: true });
+    await copyFile(source, dest);
+    await chmod3(dest, 493).catch(() => {
+    });
+    const result = await mergeHook(env, dest);
+    if (result === "skipped-unparseable") {
+      log(`Your ${settingsPath(env)} is not valid JSON, so it was left untouched.`);
+      log("Fix it (or remove it) and re-run, or install the Claude Code plugin instead.");
+      return 1;
+    }
+    log(
+      result === "added" ? "Installed the add-reasoning-to-prs hook into Claude Code." : "add-reasoning-to-prs is already installed \u2014 settings unchanged."
+    );
+    log(`  Hook: PreToolUse (Bash) \u2192 node ${dest} hook`);
+    log(`  Disable per repo: git config add-reasoning-to-prs.disabled true`);
+    log("");
+    log(UPGRADE_CTA);
+    return 0;
+  } catch (e) {
+    log(`Install failed: ${e.message}`);
+    log("You can also install the Claude Code plugin from the marketplace instead.");
+    return 1;
+  }
+}
+
 // src/cli.ts
 function help() {
   return `add-reasoning-to-prs ${VERSION}
@@ -590,11 +683,15 @@ assumptions, and limitations behind a change \u2014 into your PR description (or
 message on a direct push) at the moment the PR is opened.
 
 Usage:
+  add-reasoning-to-prs [install]    Install the hook into Claude Code (default)
   add-reasoning-to-prs --version    Print the version and exit
   add-reasoning-to-prs --help       Show this help
 
 Install into Claude Code:
-  npx add-reasoning-to-prs
+  npx add-reasoning-to-prs           # or install the plugin from the marketplace
+
+Turn it off for a repo:
+  git config add-reasoning-to-prs.disabled true
 `;
 }
 async function run(argv) {
@@ -612,6 +709,13 @@ async function run(argv) {
   }
   if (cmd === "scratch") {
     return runScratch(args.slice(1));
+  }
+  if (cmd === "--help" || cmd === "-h" || cmd === "help") {
+    process.stdout.write(help());
+    return 0;
+  }
+  if (cmd === void 0 || cmd === "install") {
+    return runInstall();
   }
   process.stdout.write(help());
   return 0;

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,5 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { run } from './cli.js';
 import { VERSION } from './version.js';
 
@@ -33,15 +36,33 @@ test('-v is an alias for --version', async () => {
   assert.equal(out.trim(), VERSION);
 });
 
-test('no args prints usage and exits 0', async () => {
-  const { code, out } = await withCapturedStdout(() => run(['node', 'bin']));
-  assert.equal(code, 0);
-  assert.match(out, /add-reasoning-to-prs/);
-  assert.match(out, /Usage:/);
-});
-
 test('--help prints usage and exits 0', async () => {
   const { code, out } = await withCapturedStdout(() => run(['node', 'bin', '--help']));
   assert.equal(code, 0);
   assert.match(out, /Usage:/);
+});
+
+test('no args runs install (writes the PreToolUse hook into settings.json)', async () => {
+  // The bare `npx add-reasoning-to-prs` installs. run() reads process.env, so isolate the
+  // config + state dirs to temp locations and restore them afterward.
+  const claude = await mkdtemp(join(tmpdir(), 'arp-claude-'));
+  const state = await mkdtemp(join(tmpdir(), 'arp-inst-'));
+  const prev = {
+    c: process.env.CLAUDE_CONFIG_DIR,
+    s: process.env.ADD_REASONING_TO_PRS_STATE_DIR,
+  };
+  process.env.CLAUDE_CONFIG_DIR = claude;
+  process.env.ADD_REASONING_TO_PRS_STATE_DIR = state;
+  try {
+    const { code } = await withCapturedStdout(() => run(['node', 'bin']));
+    assert.equal(code, 0);
+    const settings = await readFile(join(claude, 'settings.json'), 'utf8');
+    assert.match(settings, /add-reasoning-to-prs/);
+    assert.match(settings, /PreToolUse/);
+  } finally {
+    if (prev.c === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = prev.c;
+    if (prev.s === undefined) delete process.env.ADD_REASONING_TO_PRS_STATE_DIR;
+    else process.env.ADD_REASONING_TO_PRS_STATE_DIR = prev.s;
+  }
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import { VERSION } from './version.js';
 import { readRawStdin } from './stdin.js';
 import { runHook } from './hook.js';
 import { runScratch } from './scratchCommand.js';
+import { runInstall } from './install.js';
 
 export function help(): string {
   return `add-reasoning-to-prs ${VERSION}
@@ -20,11 +21,15 @@ assumptions, and limitations behind a change — into your PR description (or yo
 message on a direct push) at the moment the PR is opened.
 
 Usage:
+  add-reasoning-to-prs [install]    Install the hook into Claude Code (default)
   add-reasoning-to-prs --version    Print the version and exit
   add-reasoning-to-prs --help       Show this help
 
 Install into Claude Code:
-  npx add-reasoning-to-prs
+  npx add-reasoning-to-prs           # or install the plugin from the marketplace
+
+Turn it off for a repo:
+  git config add-reasoning-to-prs.disabled true
 `;
 }
 
@@ -58,7 +63,18 @@ export async function run(argv: string[]): Promise<number> {
     return runScratch(args.slice(1));
   }
 
-  // Default (no args) and explicit help both print usage.
+  if (cmd === '--help' || cmd === '-h' || cmd === 'help') {
+    process.stdout.write(help());
+    return 0;
+  }
+
+  // The bare `npx add-reasoning-to-prs` (or an explicit `install`) installs the hook —
+  // this is the advertised one-command install.
+  if (cmd === undefined || cmd === 'install') {
+    return runInstall();
+  }
+
+  // Anything unrecognized → help.
   process.stdout.write(help());
   return 0;
 }

--- a/src/install.test.ts
+++ b/src/install.test.ts
@@ -1,0 +1,73 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runInstall, installedBinPath } from './install.js';
+
+async function fixture() {
+  const claude = await mkdtemp(join(tmpdir(), 'arp-claude-'));
+  const state = await mkdtemp(join(tmpdir(), 'arp-inst-'));
+  const srcDir = await mkdtemp(join(tmpdir(), 'arp-src-'));
+  const source = join(srcDir, 'bundle.js');
+  await writeFile(source, '#!/usr/bin/env node\n// a stand-in bundle\n');
+  const logs: string[] = [];
+  const env = { CLAUDE_CONFIG_DIR: claude, ADD_REASONING_TO_PRS_STATE_DIR: state };
+  return { claude, state, source, env, logs, log: (m: string) => logs.push(m) };
+}
+
+const settingsOf = async (claude: string) =>
+  JSON.parse(await readFile(join(claude, 'settings.json'), 'utf8'));
+
+test('install copies the bundle and adds the PreToolUse/Bash hook', async () => {
+  const f = await fixture();
+  const code = await runInstall({ env: f.env, sourceBinPath: f.source, log: f.log });
+  assert.equal(code, 0);
+  // The self-contained bundle is copied to a stable path.
+  assert.match(await readFile(installedBinPath(f.env), 'utf8'), /stand-in bundle/);
+  // settings.json gains our hook.
+  const pre = (await settingsOf(f.claude)).hooks.PreToolUse;
+  assert.equal(pre.length, 1);
+  assert.equal(pre[0].matcher, 'Bash');
+  assert.match(pre[0].hooks[0].command, /add-reasoning-to-prs\.js" hook$/);
+  // The upgrade CTA is printed.
+  assert.match(f.logs.join('\n'), /why\.backthread\.dev/);
+});
+
+test('install is idempotent (a second run does not duplicate the hook)', async () => {
+  const f = await fixture();
+  await runInstall({ env: f.env, sourceBinPath: f.source, log: () => {} });
+  await runInstall({ env: f.env, sourceBinPath: f.source, log: () => {} });
+  assert.equal((await settingsOf(f.claude)).hooks.PreToolUse.length, 1);
+});
+
+test('install preserves existing settings and other hooks', async () => {
+  const f = await fixture();
+  await mkdir(f.claude, { recursive: true });
+  await writeFile(
+    join(f.claude, 'settings.json'),
+    JSON.stringify({
+      model: 'opus',
+      hooks: { PreToolUse: [{ matcher: 'Read', hooks: [{ type: 'command', command: 'echo hi' }] }] },
+    }),
+  );
+  await runInstall({ env: f.env, sourceBinPath: f.source, log: () => {} });
+  const s = await settingsOf(f.claude);
+  assert.equal(s.model, 'opus'); // untouched
+  assert.equal(s.hooks.PreToolUse.length, 2); // existing + ours
+  assert.ok(s.hooks.PreToolUse.some((e: { matcher: string }) => e.matcher === 'Read'));
+  assert.ok(
+    s.hooks.PreToolUse.some((e: { hooks: { command: string }[] }) =>
+      e.hooks[0].command.includes('add-reasoning-to-prs'),
+    ),
+  );
+});
+
+test('install refuses to clobber an unparseable settings.json', async () => {
+  const f = await fixture();
+  await mkdir(f.claude, { recursive: true });
+  await writeFile(join(f.claude, 'settings.json'), '{ not valid json ');
+  const code = await runInstall({ env: f.env, sourceBinPath: f.source, log: f.log });
+  assert.equal(code, 1);
+  assert.equal(await readFile(join(f.claude, 'settings.json'), 'utf8'), '{ not valid json ');
+});

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,0 +1,150 @@
+// install.ts — `npx add-reasoning-to-prs` (the bare command) installs the hook into the
+// user's Claude Code settings.
+//
+// The Claude Code PLUGIN (marketplace) is the recommended install — it registers the hook
+// from the plugin manifest with no settings mutation, running the committed bundle via
+// ${CLAUDE_PLUGIN_ROOT}. This path is the alternative for non-plugin users: because the
+// hook is SYNCHRONOUS (a PreToolUse decision), it must not pay npm-resolve latency on
+// every Bash call — so instead of an `npx …` hook command, we COPY the self-contained,
+// zero-dependency bundle to a stable location and point the settings.json hook at it with
+// plain `node`.
+
+import { homedir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { readFile, writeFile, mkdir, copyFile, chmod } from 'node:fs/promises';
+
+export interface InstallDeps {
+  env?: NodeJS.ProcessEnv;
+  /** The bundle to copy. Defaults to this running bin (the bundle itself under npx). */
+  sourceBinPath?: string;
+  /** Where human-readable output goes. Defaults to stdout. */
+  log?: (msg: string) => void;
+}
+
+export const UPGRADE_CTA = `Your agent now writes the "why" into every PR — locally, on your own model, free.
+Want the team view — the why pushed to you and searchable across your whole codebase?
+  → https://why.backthread.dev   (how it works)
+  → https://get.backthread.dev   (get the hosted upgrade)`;
+
+function claudeDir(env: NodeJS.ProcessEnv): string {
+  const override = env.CLAUDE_CONFIG_DIR;
+  return override && override.trim().length > 0 ? override : join(homedir(), '.claude');
+}
+
+function settingsPath(env: NodeJS.ProcessEnv): string {
+  return join(claudeDir(env), 'settings.json');
+}
+
+function installDir(env: NodeJS.ProcessEnv): string {
+  const override = env.ADD_REASONING_TO_PRS_STATE_DIR;
+  const base = override && override.trim().length > 0 ? override : join(homedir(), '.add-reasoning-to-prs');
+  return join(base, 'bin');
+}
+
+export function installedBinPath(env: NodeJS.ProcessEnv = process.env): string {
+  return join(installDir(env), 'add-reasoning-to-prs.js');
+}
+
+/** True if some PreToolUse entry already runs our hook (idempotency). */
+function alreadyInstalled(preToolUse: unknown): boolean {
+  if (!Array.isArray(preToolUse)) return false;
+  return preToolUse.some(
+    (entry) =>
+      entry &&
+      typeof entry === 'object' &&
+      Array.isArray((entry as { hooks?: unknown }).hooks) &&
+      (entry as { hooks: unknown[] }).hooks.some(
+        (h) =>
+          h &&
+          typeof h === 'object' &&
+          typeof (h as { command?: unknown }).command === 'string' &&
+          (h as { command: string }).command.includes('add-reasoning-to-prs'),
+      ),
+  );
+}
+
+/**
+ * Merge the PreToolUse/Bash hook into settings.json. Returns 'added', 'present' (already
+ * installed), or 'skipped-unparseable' (existing settings.json isn't valid JSON — we do
+ * NOT clobber it). Never throws.
+ */
+async function mergeHook(
+  env: NodeJS.ProcessEnv,
+  binPath: string,
+): Promise<'added' | 'present' | 'skipped-unparseable'> {
+  const path = settingsPath(env);
+  let raw: string | null = null;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch {
+    raw = null; // absent → we'll create it
+  }
+
+  let settings: Record<string, unknown> = {};
+  if (raw !== null) {
+    try {
+      const parsed = JSON.parse(raw);
+      settings = parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+    } catch {
+      return 'skipped-unparseable'; // never overwrite a file we can't parse
+    }
+  }
+
+  const hooks = (settings.hooks && typeof settings.hooks === 'object' ? settings.hooks : {}) as Record<
+    string,
+    unknown
+  >;
+  const preToolUse = Array.isArray(hooks.PreToolUse) ? (hooks.PreToolUse as unknown[]) : [];
+  if (alreadyInstalled(preToolUse)) return 'present';
+
+  preToolUse.push({
+    matcher: 'Bash',
+    hooks: [{ type: 'command', command: `node ${JSON.stringify(binPath)} hook` }],
+  });
+  hooks.PreToolUse = preToolUse;
+  settings.hooks = hooks;
+
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(settings, null, 2) + '\n');
+  return 'added';
+}
+
+/** Install the hook. Copies the bundle to a stable path, merges the settings.json hook,
+ * prints a summary + the upgrade CTA. Returns an exit code (0 on success). */
+export async function runInstall(deps: InstallDeps = {}): Promise<number> {
+  const env = deps.env ?? process.env;
+  const log = deps.log ?? ((m: string) => process.stdout.write(m + '\n'));
+  const source = deps.sourceBinPath ?? fileURLToPath(import.meta.url);
+
+  try {
+    // 1. Copy the self-contained bundle to a stable location.
+    const dest = installedBinPath(env);
+    await mkdir(dirname(dest), { recursive: true });
+    await copyFile(source, dest);
+    await chmod(dest, 0o755).catch(() => {});
+
+    // 2. Merge the hook into settings.json.
+    const result = await mergeHook(env, dest);
+
+    if (result === 'skipped-unparseable') {
+      log(`Your ${settingsPath(env)} is not valid JSON, so it was left untouched.`);
+      log('Fix it (or remove it) and re-run, or install the Claude Code plugin instead.');
+      return 1;
+    }
+    log(
+      result === 'added'
+        ? 'Installed the add-reasoning-to-prs hook into Claude Code.'
+        : 'add-reasoning-to-prs is already installed — settings unchanged.',
+    );
+    log(`  Hook: PreToolUse (Bash) → node ${dest} hook`);
+    log(`  Disable per repo: git config add-reasoning-to-prs.disabled true`);
+    log('');
+    log(UPGRADE_CTA);
+    return 0;
+  } catch (e) {
+    log(`Install failed: ${(e as Error).message}`);
+    log('You can also install the Claude Code plugin from the marketplace instead.');
+    return 1;
+  }
+}

--- a/src/manifest.test.ts
+++ b/src/manifest.test.ts
@@ -1,0 +1,38 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const readJson = (rel: string): Record<string, unknown> =>
+  JSON.parse(readFileSync(join(root, rel), 'utf8'));
+
+test('plugin manifest has the required fields', () => {
+  const p = readJson('.claude-plugin/plugin.json');
+  assert.equal(p.name, 'add-reasoning-to-prs');
+  assert.equal(typeof p.description, 'string');
+  assert.equal(typeof p.version, 'string');
+});
+
+test('marketplace manifest is valid and lists the plugin at ./', () => {
+  const m = readJson('.claude-plugin/marketplace.json') as {
+    name: string;
+    plugins: Array<Record<string, unknown>>;
+  };
+  assert.equal(typeof m.name, 'string');
+  assert.ok(Array.isArray(m.plugins) && m.plugins.length >= 1);
+  const plugin = m.plugins[0];
+  assert.equal(plugin.name, 'add-reasoning-to-prs');
+  assert.equal(plugin.source, './');
+  assert.equal(plugin.license, 'MIT');
+});
+
+test('the plugin hook registers PreToolUse/Bash against the bundled bin', () => {
+  const hooks = readJson('hooks/hooks.json') as {
+    hooks: { PreToolUse: Array<{ matcher: string; hooks: Array<{ command: string }> }> };
+  };
+  const entry = hooks.hooks.PreToolUse[0];
+  assert.equal(entry.matcher, 'Bash');
+  assert.match(entry.hooks[0].command, /CLAUDE_PLUGIN_ROOT.*dist-bundle\/add-reasoning-to-prs\.js.*hook/);
+});


### PR DESCRIPTION
## Install + Claude Code plugin packaging

### One-command install (`install.ts`)
`npx add-reasoning-to-prs` (the bare command) installs the hook:
1. Copies the **self-contained, zero-dependency bundle** to a stable path (`~/.add-reasoning-to-prs/bin/`).
2. Merges a `PreToolUse` (matcher `Bash`) hook into `~/.claude/settings.json` pointing at that copy with plain `node`.

Why copy instead of an `npx …` hook command? The hook is **synchronous** (a PreToolUse decision), so it must not pay npm-resolve latency on every Bash call. The bundle is zero-dependency, so a plain `node <path> hook` is instant.

Safety:
- **Idempotent** — a second run doesn't duplicate the hook.
- **Preserves** existing settings and any other hooks (deep-merges into `PreToolUse`).
- **Never clobbers** an unparseable `settings.json` — it bails with a message instead.

### Claude Code plugin (`.claude-plugin/marketplace.json`)
Adds the marketplace listing (`source: "./"`) so the hook can also be installed as a **plugin** — the recommended path: it registers from the manifest via `${CLAUDE_PLUGIN_ROOT}` with **no settings mutation** and updates with the plugin. (`plugin.json` + `hooks/hooks.json` already shipped earlier.)

### Hosted-version links
A soft, copy-only link to the hosted version (`why.backthread.dev` / `get.backthread.dev`) in the install output and the README. No landing pages here — copy only.

### Done when
- **One-command install works** — verified end-to-end through the built bundle: `settings.json` gets the hook, the copied bin runs (`--version`), and a re-run is idempotent.
- **Plugin manifest validates** — `manifest.test.ts` checks the plugin + marketplace manifests and the plugin hook registration.

### Testing
- `npm run typecheck` clean; `npm test` 65/65.

