### PR TITLE
Write the why-block plainly (non-native readability)

### DIFF
--- a/dist-bundle/add-reasoning-to-prs.js
+++ b/dist-bundle/add-reasoning-to-prs.js
@@ -438,6 +438,9 @@ Rules:
 - Forward-only: capture what the diff can't show \u2014 the why, and the risks knowingly taken. Never summarize the changes.
 - Grounded: every line must trace to real deliberation in this session. Cut anything padded, generic, or inferred.
 - Keep it tight: a few lines per section at most.
+- Write it plainly \u2014 the reviewer may not be a native English speaker. One idea per sentence; prefer several short sentences over one long one with stacked clauses.
+- Use plain words, not idioms or metaphors \u2014 say the literal thing ("follow foreign keys", not "hop the graph"; "turn it off", not "kill-switch"). Keep real names (tables, flags, functions, endpoints, keys) exactly \u2014 never trade a concrete name for a vague one.
+- Avoid "X \u2192 Y" / "X: Y" logic shorthand; write it as a sentence (a relationship example like \`a\` \u2192 \`b\` is fine). For a risk, end with a short action the reviewer can take, e.g. "Check: review both lists".
 - Wrap the block EXACTLY between the two markers below so it is detected and left untouched on later runs:
 
 ${exampleBlock(surface)}

--- a/src/guidance.test.ts
+++ b/src/guidance.test.ts
@@ -31,3 +31,12 @@ test('guidance makes the leave-empty path explicit (no manufactured filler)', ()
   assert.ok(g.includes(SKIP_TOKEN), 'guidance should surface the explicit skip escape hatch');
   assert.match(g, /never manufacture filler/i);
 });
+
+test('guidance tells the model to write plainly (non-native-reader friendly)', () => {
+  const g = buildGuidance('pr');
+  assert.match(g, /native English speaker/i);
+  assert.match(g, /one idea per sentence/i);
+  assert.match(g, /not idioms or metaphors/i);
+  assert.match(g, /never trade a concrete name for a vague one/i);
+  assert.match(g, /end with a short action/i);
+});

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -89,6 +89,9 @@ Rules:
 - Forward-only: capture what the diff can't show — the why, and the risks knowingly taken. Never summarize the changes.
 - Grounded: every line must trace to real deliberation in this session. Cut anything padded, generic, or inferred.
 - Keep it tight: a few lines per section at most.
+- Write it plainly — the reviewer may not be a native English speaker. One idea per sentence; prefer several short sentences over one long one with stacked clauses.
+- Use plain words, not idioms or metaphors — say the literal thing ("follow foreign keys", not "hop the graph"; "turn it off", not "kill-switch"). Keep real names (tables, flags, functions, endpoints, keys) exactly — never trade a concrete name for a vague one.
+- Avoid "X → Y" / "X: Y" logic shorthand; write it as a sentence (a relationship example like \`a\` → \`b\` is fine). For a risk, end with a short action the reviewer can take, e.g. "Check: review both lists".
 - Wrap the block EXACTLY between the two markers below so it is detected and left untouched on later runs:
 
 ${exampleBlock(surface)}


### PR DESCRIPTION
## Tell the model to write the why-block plainly (non-native readability)

The injected guidance produced blocks that were terse but **idiom- and clause-heavy**, so the composed block read hard for a non-native English reviewer. On a real security PR the block read hard — the highest-*value* section was the hardest to *read*, which is backwards.

Root cause: the hook's `guidance.ts` had no plain-language rules — only "keep it tight" — so the block inherited long stacked clauses, `⇒`/`:` logic shorthand, and metaphors like "hop the FK graph".

### Change
Three plain-language rules added to the injected guidance (and the rules are themselves written one-idea-per-sentence, so they model the behavior):
- **One idea per sentence** — prefer several short sentences over one long one with stacked clauses.
- **Plain words, not idioms/metaphors** — say the literal thing (*"follow foreign keys"*, not *"hop the graph"*; *"turn it off"*, not *"kill-switch"*) — **but keep real names** (tables, flags, functions, endpoints) exactly; never trade a concrete anchor for a vague word.
- **No `X → Y` / `X: Y` logic shorthand** — write it as a sentence; end a risk with a short action, e.g. *"Check: review both lists."*

### How it was chosen
Iterated the rules on that same PR against a fixed readability/usefulness rubric. The block got substantially easier to read while staying just as useful (every concrete technical anchor kept). The key guard: an over-plain variant that swapped technical names for lay words read easier but became less useful — *plain ≠ vague* — so it lost. The winning ruleset keeps the technical anchors and only simplifies structure and vocabulary.

### Done when
- Plain-language rules ship in the injected guidance — verified through the built bundle (the PR-surface deny reason now carries all three).

### Testing
- `npm run typecheck` clean; `npm test` 66/66; `npm run e2e` 17/17.

