### PR TITLE
Add optional "Recommended follow-ups" section (PR surface only)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "add-reasoning-to-prs",
   "displayName": "Add Reasoning to PRs",
   "description": "Writes a forward-only \"why\" block (decisions, trade-offs, assumptions, limitations) into your PR description or commit message at PR-create / direct-push time — composed by your own agent, in-session, with no account and no server round-trip.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Backthread"
   },

--- a/dist-bundle/add-reasoning-to-prs.js
+++ b/dist-bundle/add-reasoning-to-prs.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // src/version.ts
-var VERSION = "1.0.0" ? "1.0.0" : readPackageVersion();
+var VERSION = "1.1.0" ? "1.1.0" : readPackageVersion();
 
 // src/stdin.ts
 async function readRawStdin(env = process.env, stdin = process.stdin) {

--- a/dist-bundle/add-reasoning-to-prs.js
+++ b/dist-bundle/add-reasoning-to-prs.js
@@ -261,6 +261,16 @@ var FILLER_PATTERNS = [
   /^(code\s+)?(quality|cleanup|refactor(ing)?|polish)\.?$/i,
   /^no\s+(notable\s+)?(decisions?|changes?|deliberation)\.?$/i
 ];
+var FOLLOWUP_FILLER_PATTERNS = [
+  /^(add|write)\s+(more\s+|extra\s+|unit\s+|integration\s+)?tests?\.?$/i,
+  /^(add|improve|better|more)\s+(the\s+)?(error[\s-]?handling|logging|validation|documentation|docs|comments?|monitoring|observability|metrics|telemetry|type\s+safety|test\s+coverage|coverage)\.?$/i,
+  /^update\s+(the\s+)?(docs|documentation|readme)\.?$/i,
+  /^(consider\s+|maybe\s+)?refactor(ing)?(\s+(this|it|later))?\.?$/i,
+  /^(optimi[sz]e|clean\s*up|polish|revisit|monitor|review|simplify)(\s+(this|it|later|performance))?\.?$/i,
+  /^(handle|cover)\s+(the\s+)?(remaining\s+)?edge\s+cases?\.?$/i,
+  /^(add|set\s*up)\s+(monitoring|alerting|observability|metrics)\.?$/i,
+  /^follow[\s-]?ups?\.?$/i
+];
 function debullet(line) {
   return line.replace(/^\s*[-*]\s*/, "").trim();
 }
@@ -269,12 +279,16 @@ function isPadding(line) {
   if (t.length === 0) return true;
   return FILLER_PATTERNS.some((re) => re.test(t));
 }
-function scrubLines(lines) {
+function isPaddingFollowup(line) {
+  if (isPadding(line)) return true;
+  return FOLLOWUP_FILLER_PATTERNS.some((re) => re.test(debullet(line)));
+}
+function scrubLines(lines, isFiller = isPadding) {
   const seen = /* @__PURE__ */ new Set();
   const out = [];
   for (const raw of Array.isArray(lines) ? lines : []) {
     if (typeof raw !== "string") continue;
-    if (isPadding(raw)) continue;
+    if (isFiller(raw)) continue;
     const key = debullet(raw).toLowerCase();
     if (seen.has(key)) continue;
     seen.add(key);
@@ -282,23 +296,34 @@ function scrubLines(lines) {
   }
   return out;
 }
+function scrubFollowups(lines) {
+  return scrubLines(lines, isPaddingFollowup);
+}
 function scrubPrimitives(p) {
-  return {
+  const out = {
     decisions: scrubLines(p.decisions ?? []),
     assumptions: scrubLines(p.assumptions ?? []),
     tradeoffs: scrubLines(p.tradeoffs ?? []),
     limitations: scrubLines(p.limitations ?? [])
   };
+  if (p.followups !== void 0) out.followups = scrubFollowups(p.followups ?? []);
+  return out;
 }
 
 // src/template.ts
 var PRIMITIVES = ["decisions", "assumptions", "tradeoffs", "limitations"];
+var PR_ONLY_PRIMITIVES = ["followups"];
+var ALL_PRIMITIVES = [...PRIMITIVES, ...PR_ONLY_PRIMITIVES];
 var HEADINGS = {
   decisions: "Decisions",
   assumptions: "Assumptions",
   tradeoffs: "Trade-offs",
-  limitations: "Limitations"
+  limitations: "Limitations",
+  followups: "Recommended follow-ups"
 };
+function primitivesForSurface(surface) {
+  return surface === "pr" ? ALL_PRIMITIVES : PRIMITIVES;
+}
 function delimiters(surface) {
   return surface === "pr" ? { open: PR_MARKER_OPEN, close: PR_MARKER_CLOSE } : { open: COMMIT_MARKER_OPEN, close: COMMIT_MARKER_CLOSE };
 }
@@ -307,14 +332,15 @@ function clean(items) {
   return items.map((s) => typeof s === "string" ? s.trim() : "").filter(Boolean);
 }
 function isEmptyBlock(p) {
-  return PRIMITIVES.every((k) => clean(p[k]).length === 0);
+  return ALL_PRIMITIVES.every((k) => clean(p[k]).length === 0);
 }
 function renderBlock(surface, p) {
-  if (isEmptyBlock(p)) return "";
+  const keys = primitivesForSurface(surface);
+  if (keys.every((k) => clean(p[k]).length === 0)) return "";
   const { open, close } = delimiters(surface);
   const isPr = surface === "pr";
   const lines = [open];
-  for (const key of PRIMITIVES) {
+  for (const key of keys) {
     const items = clean(p[key]);
     if (items.length === 0) continue;
     lines.push(isPr ? `**${HEADINGS[key]}**` : `${HEADINGS[key]}:`);
@@ -413,7 +439,9 @@ function exampleBlock(surface) {
     decisions: placeholder,
     assumptions: placeholder,
     tradeoffs: placeholder,
-    limitations: placeholder
+    limitations: placeholder,
+    // Renders only on the PR surface (renderBlock drops it on the commit surface).
+    followups: placeholder
   });
   const body = rendered.slice(open.length, rendered.length - close.length).trim();
   return [open, attributionHeader(surface), "", body, "", attributionFooter(surface), close].join(
@@ -432,12 +460,23 @@ function renderAccumulated(p) {
 }
 function buildGuidance(surface, accumulated) {
   const c = surfaceCopy(surface);
+  const isPr = surface === "pr";
   const earlier = accumulated && !isEmptyBlock(accumulated) ? `
 
 Earlier work on this branch (possibly a different session) already recorded these \u2014 fold the still-relevant points into the block instead of pasting them, and drop anything now stale:
 
 ${renderAccumulated(accumulated)}
 ` : "";
+  const followupsBullet = isPr ? `
+- Recommended follow-ups \u2014 a concrete next step your reasoning surfaced that a reviewer could NOT get from this diff alone. Most PRs have none.` : "";
+  const followupsGuidance = isPr ? `
+
+Recommended follow-ups (pull requests only):
+- Add this section ONLY for a follow-up that your in-session reasoning surfaced AND a reviewer could not see from this PR's diff alone. Prefer a consequence in another file, another repository, or another service.
+- Precision over coverage. If a careful reviewer could also reach the item by reading this diff, drop it. Most PRs have no follow-up. An empty section is the normal, correct outcome.
+- Exclude anything a normal code review, a linter, or CI already catches. This is not a review checklist.
+- Name the exact repository, file, or function only when it appeared in this session. Never guess a path. A wrong path is worse than none.
+- One risk has one home. If you already stated a risk in Assumptions or Limitations and ended it with a "Check: ..." action, move that action here and remove the "Check: ..." tail there, so the same action is not written twice.` : "";
   return `add-reasoning-to-prs: before ${c.moment}, add a short, forward-only "why" block to ${c.where}, then re-run the command.${earlier}
 
 Write the block ONLY from what you actually decided in THIS session \u2014 never invent. Use only the sections that apply:
@@ -445,7 +484,7 @@ Write the block ONLY from what you actually decided in THIS session \u2014 never
 - Decisions \u2014 the choices you made and why (not what changed; the diff already shows that).
 - Assumptions \u2014 what you took as given that a reviewer should confirm.
 - Trade-offs \u2014 what you knowingly gave up, and the option you rejected.
-- Limitations \u2014 known gaps or risks you are deliberately leaving.
+- Limitations \u2014 known gaps or risks you are deliberately leaving.${followupsBullet}
 
 How much to write:
 - Size the block to the change. Most PRs need one to three lines, not four full sections. A small or mechanical PR gets one line, or none.
@@ -457,7 +496,7 @@ Be honest:
 - Forward-only: capture what the diff can't show \u2014 the why, and the risks knowingly taken. Never summarize the changes.
 - Every line must trace to a real decision in this session. If the reason was never stated, drop the line \u2014 do not guess it.
 - Never restate the diff ("added X", "refactored Y"), and never pad with filler ("improves code quality", "various cleanups").
-- Write a caveat as a claim plus its silent consequence: "Assumes X; if X is wrong, Y breaks." A caveat with no named consequence is filler \u2014 cut it. End a risk with a short action, e.g. "Check: review both lists".
+- Write a caveat as a claim plus its silent consequence: "Assumes X; if X is wrong, Y breaks." A caveat with no named consequence is filler \u2014 cut it. End a risk with a short action, e.g. "Check: review both lists".${followupsGuidance}
 
 Write it plainly \u2014 the reviewer may not be a native English speaker:
 - One idea per sentence; prefer several short sentences over one long one with stacked clauses.
@@ -466,7 +505,7 @@ Write it plainly \u2014 the reviewer may not be a native English speaker:
 - Plain, factual, senior-engineer voice. No self-praise or marketing words (no "elegant", "robust", "clean", "seamless", "improves quality"). Say only what you decided and what is risky.
 
 Format:
-- Keep the four headings in this order; include only the non-empty ones.
+- Keep the headings in the order shown; include only the non-empty ones.
 - Wrap the block EXACTLY between the two markers below so it is detected and left untouched on later runs.
 - Add a visible attribution INSIDE the markers, scaled to the block. A substantial block uses the full attribution shown below (the heading/opening line plus the small closing note); a one- or two-line block uses only a single compact attribution line. Never a banner.
 

--- a/dist-bundle/add-reasoning-to-prs.js
+++ b/dist-bundle/add-reasoning-to-prs.js
@@ -476,7 +476,7 @@ Recommended follow-ups (pull requests only):
 - Precision over coverage. If a careful reviewer could also reach the item by reading this diff, drop it. Most PRs have no follow-up. An empty section is the normal, correct outcome.
 - Exclude anything a normal code review, a linter, or CI already catches. This is not a review checklist.
 - Name the exact repository, file, or function only when it appeared in this session. Never guess a path. A wrong path is worse than none.
-- One risk has one home. If you already stated a risk in Assumptions or Limitations and ended it with a "Check: ..." action, move that action here and remove the "Check: ..." tail there, so the same action is not written twice.` : "";
+- One risk has one home. Keep the inline "Check: ..." tail on a risk by default; only when that action is a cross-boundary follow-up you are promoting into this section, move it here and remove the "Check: ..." tail there \u2014 so the same action is never written twice.` : "";
   return `add-reasoning-to-prs: before ${c.moment}, add a short, forward-only "why" block to ${c.where}, then re-run the command.${earlier}
 
 Write the block ONLY from what you actually decided in THIS session \u2014 never invent. Use only the sections that apply:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "add-reasoning-to-prs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "add-reasoning-to-prs",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "bin": {
         "add-reasoning-to-prs": "dist-bundle/add-reasoning-to-prs.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-reasoning-to-prs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A Claude Code hook that writes a forward-only \"why\" block (decisions, trade-offs, assumptions, limitations) into your PR description or commit message at PR-create / direct-push time.",
   "license": "MIT",
   "author": "Backthread",

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -46,6 +46,7 @@ git -C "$REPO" checkout -q -b feat/e2e
 OUT="$(runhook "$(payload 'gh pr create --title "Add widget"' s-pr)")"
 check "PR create denies (asks for a block)"        "$(decision "$OUT")" deny
 check "  PR guidance targets the PR description"   "$(jget "$OUT" '/pull request description/i.test(h.permissionDecisionReason||"")')" true
+check "  PR guidance teaches Recommended follow-ups" "$(jget "$OUT" '/Recommended follow-ups/.test(h.permissionDecisionReason||"")')" true
 check "  additionalContext present + == reason"    "$(jget "$OUT" 'String(!!h.additionalContext && h.additionalContext===h.permissionDecisionReason)')" true
 
 # 2. Idempotent re-run — a block is already present → no-op.
@@ -57,6 +58,7 @@ git -C "$REPO" checkout -q main
 OUT="$(runhook "$(payload 'git commit -m "hotfix"' s-commit)")"
 check "commit on default branch denies"            "$(decision "$OUT")" deny
 check "  commit guidance targets the message body" "$(jget "$OUT" '/commit message body/i.test(h.permissionDecisionReason||"")')" true
+check "  commit guidance omits Recommended follow-ups" "$(jget "$OUT" 'String(!/Recommended follow-ups/.test(h.permissionDecisionReason||""))')" true
 
 # 4. Feature-branch commit never denies (defers to PR-create).
 git -C "$REPO" checkout -q feat/e2e

--- a/src/critique.test.ts
+++ b/src/critique.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { isPadding, scrubLines, scrubPrimitives } from './critique.js';
+import { isPadding, isPaddingFollowup, scrubLines, scrubFollowups, scrubPrimitives } from './critique.js';
 
 test('drops padded/filler lines but keeps genuine deliberation (the fixture)', () => {
   const input = [
@@ -67,4 +67,44 @@ test('scrubPrimitives cleans every section and leaves empties empty', () => {
     tradeoffs: [],
     limitations: ['Skipped the migration for the follow-up PR'],
   });
+  // No followups key was supplied → none is added (keeps the scratchpad JSON clean).
+  assert.ok(!('followups' in out));
+});
+
+test('scrubFollowups drops generic to-dos at the stricter bar but keeps concrete cross-boundary items', () => {
+  const kept = 'The mobile and web clients still send a legacy retryCount field the API now ignores; drop it in apps/mobile/src/api.ts';
+  const out = scrubFollowups([
+    'Add tests',
+    'consider refactoring later',
+    'improve error handling',
+    'update the docs',
+    'handle edge cases',
+    'add monitoring',
+    'follow-up',
+    kept,
+  ]);
+  assert.deepEqual(out, [kept]);
+});
+
+test('the stricter follow-up bar is a SUPERSET of the base bar', () => {
+  // Generic to-dos are padding for follow-ups but NOT for the base primitives.
+  assert.equal(isPaddingFollowup('Add tests'), true);
+  assert.equal(isPadding('Add tests'), false);
+  assert.equal(isPaddingFollowup('consider refactoring later'), true);
+  // A concrete item that merely starts with a generic verb survives both.
+  const concrete = 'Add tests for the cross-service billing webhook contract in packages/billing/webhook.ts';
+  assert.equal(isPaddingFollowup(concrete), false);
+  // Base filler is still filler for follow-ups.
+  assert.equal(isPaddingFollowup('various improvements'), true);
+});
+
+test('scrubPrimitives applies the stricter bar to followups only', () => {
+  const out = scrubPrimitives({
+    decisions: ['Add tests'], // NOT dropped — the base bar keeps change-verb lines
+    followups: ['Add tests', 'applyDiscount duplicates the pricing branch order in the checkout service'],
+  });
+  assert.deepEqual(out.decisions, ['Add tests']);
+  assert.deepEqual(out.followups, [
+    'applyDiscount duplicates the pricing branch order in the checkout service',
+  ]);
 });

--- a/src/critique.ts
+++ b/src/critique.ts
@@ -30,6 +30,24 @@ const FILLER_PATTERNS: RegExp[] = [
   /^no\s+(notable\s+)?(decisions?|changes?|deliberation)\.?$/i,
 ];
 
+// STRICTER whole-line filler for the Recommended-follow-ups section only. A follow-up must
+// name a concrete, not-derivable-from-the-diff consequence; a bare generic to-do ("add
+// tests", "consider refactoring later", "improve error handling") is exactly the padding the
+// higher bar exists to cut. Anchored (^…$) against the de-bulleted line, so a follow-up that
+// merely STARTS with one of these but carries a concrete target survives (e.g. "Add tests for
+// the cross-service billing webhook contract in packages/billing/webhook.ts" is kept — it says more than "add
+// tests"). This stays deterministic filler removal; it never tries to judge grounding.
+const FOLLOWUP_FILLER_PATTERNS: RegExp[] = [
+  /^(add|write)\s+(more\s+|extra\s+|unit\s+|integration\s+)?tests?\.?$/i,
+  /^(add|improve|better|more)\s+(the\s+)?(error[\s-]?handling|logging|validation|documentation|docs|comments?|monitoring|observability|metrics|telemetry|type\s+safety|test\s+coverage|coverage)\.?$/i,
+  /^update\s+(the\s+)?(docs|documentation|readme)\.?$/i,
+  /^(consider\s+|maybe\s+)?refactor(ing)?(\s+(this|it|later))?\.?$/i,
+  /^(optimi[sz]e|clean\s*up|polish|revisit|monitor|review|simplify)(\s+(this|it|later|performance))?\.?$/i,
+  /^(handle|cover)\s+(the\s+)?(remaining\s+)?edge\s+cases?\.?$/i,
+  /^(add|set\s*up)\s+(monitoring|alerting|observability|metrics)\.?$/i,
+  /^follow[\s-]?ups?\.?$/i,
+];
+
 /** Strip a leading markdown bullet and surrounding whitespace. */
 function debullet(line: string): string {
   return line.replace(/^\s*[-*]\s*/, '').trim();
@@ -42,13 +60,24 @@ export function isPadding(line: string): boolean {
   return FILLER_PATTERNS.some((re) => re.test(t));
 }
 
-/** Drop filler + exact-duplicate lines, preserving order and original wording. */
-export function scrubLines(lines: string[]): string[] {
+/** True if a Recommended-follow-ups line is padding at the STRICTER bar (the base filler
+ * test plus the generic-to-do patterns above). */
+export function isPaddingFollowup(line: string): boolean {
+  if (isPadding(line)) return true;
+  return FOLLOWUP_FILLER_PATTERNS.some((re) => re.test(debullet(line)));
+}
+
+/** Drop filler + exact-duplicate lines, preserving order and original wording. `isFiller`
+ * selects the bar — the default base filter, or the stricter follow-up filter. */
+export function scrubLines(
+  lines: string[],
+  isFiller: (line: string) => boolean = isPadding,
+): string[] {
   const seen = new Set<string>();
   const out: string[] = [];
   for (const raw of Array.isArray(lines) ? lines : []) {
     if (typeof raw !== 'string') continue;
-    if (isPadding(raw)) continue;
+    if (isFiller(raw)) continue;
     const key = debullet(raw).toLowerCase();
     if (seen.has(key)) continue; // de-duplicate (case-insensitive)
     seen.add(key);
@@ -57,12 +86,20 @@ export function scrubLines(lines: string[]): string[] {
   return out;
 }
 
-/** Scrub every primitive's lines. Empty sections simply become empty arrays. */
+/** Scrub Recommended-follow-ups lines at the stricter bar (generic to-dos cut as padding). */
+export function scrubFollowups(lines: string[]): string[] {
+  return scrubLines(lines, isPaddingFollowup);
+}
+
+/** Scrub every primitive's lines. Empty sections simply become empty arrays. The PR-only
+ * `followups` field is scrubbed at the stricter bar and only included when it was present. */
 export function scrubPrimitives(p: WhyPrimitives): WhyPrimitives {
-  return {
+  const out: WhyPrimitives = {
     decisions: scrubLines(p.decisions ?? []),
     assumptions: scrubLines(p.assumptions ?? []),
     tradeoffs: scrubLines(p.tradeoffs ?? []),
     limitations: scrubLines(p.limitations ?? []),
   };
+  if (p.followups !== undefined) out.followups = scrubFollowups(p.followups ?? []);
+  return out;
 }

--- a/src/guidance.test.ts
+++ b/src/guidance.test.ts
@@ -52,6 +52,31 @@ test('guidance carries the restraint, insight, no-self-praise, and attribution r
   assert.match(pr, /backthread\/add-reasoning-to-prs/); // attributed to the package
 });
 
+test('PR guidance teaches Recommended follow-ups: inclusion test, precision bar, de-dup rule', () => {
+  const pr = buildGuidance('pr');
+  assert.match(pr, /Recommended follow-ups/);
+  // Inclusion test: reasoning-surfaced AND not derivable from this diff.
+  assert.match(pr, /could not see from this PR's diff alone/i);
+  // Precision over coverage + empty is correct.
+  assert.match(pr, /Precision over coverage/i);
+  assert.match(pr, /empty section is the normal, correct outcome/i);
+  // Not a review/lint/CI lane.
+  assert.match(pr, /linter, or CI already catches/i);
+  // Never guess a path.
+  assert.match(pr, /Never guess a path/i);
+  // De-dup with the Check: tail.
+  assert.match(pr, /One risk has one home/i);
+  assert.match(pr, /remove the "Check: \.\.\." tail/i);
+  // The example block shows the heading on the PR surface.
+  assert.match(pr, /\*\*Recommended follow-ups\*\*/);
+});
+
+test('commit guidance NEVER mentions Recommended follow-ups (PR-only primitive)', () => {
+  const commit = buildGuidance('commit');
+  assert.doesNotMatch(commit, /Recommended follow-ups/i);
+  assert.doesNotMatch(commit, /Precision over coverage/i);
+});
+
 test('commit-surface attribution is plain text (no markdown heading, HTML, or links)', () => {
   const commit = buildGuidance('commit');
   assert.match(commit, /written in-session via backthread\/add-reasoning-to-prs/);

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -68,6 +68,8 @@ function exampleBlock(surface: Surface): string {
     assumptions: placeholder,
     tradeoffs: placeholder,
     limitations: placeholder,
+    // Renders only on the PR surface (renderBlock drops it on the commit surface).
+    followups: placeholder,
   });
   // renderBlock wraps the body in the markers; lift the body out and re-wrap it with the
   // attribution inside the same markers.
@@ -99,10 +101,26 @@ function renderAccumulated(p: WhyPrimitives): string {
  */
 export function buildGuidance(surface: Surface, accumulated?: WhyPrimitives): string {
   const c = surfaceCopy(surface);
+  const isPr = surface === 'pr';
   const earlier =
     accumulated && !isEmptyBlock(accumulated)
       ? `\n\nEarlier work on this branch (possibly a different session) already recorded these — fold the still-relevant points into the block instead of pasting them, and drop anything now stale:\n\n${renderAccumulated(accumulated)}\n`
       : '';
+  // The Recommended-follow-ups primitive renders on the PR surface only. A commit message is
+  // immutable once pushed and has no backlog home, so a forward-looking to-do has no place there.
+  const followupsBullet = isPr
+    ? `\n- Recommended follow-ups — a concrete next step your reasoning surfaced that a reviewer could NOT get from this diff alone. Most PRs have none.`
+    : '';
+  const followupsGuidance = isPr
+    ? `
+
+Recommended follow-ups (pull requests only):
+- Add this section ONLY for a follow-up that your in-session reasoning surfaced AND a reviewer could not see from this PR's diff alone. Prefer a consequence in another file, another repository, or another service.
+- Precision over coverage. If a careful reviewer could also reach the item by reading this diff, drop it. Most PRs have no follow-up. An empty section is the normal, correct outcome.
+- Exclude anything a normal code review, a linter, or CI already catches. This is not a review checklist.
+- Name the exact repository, file, or function only when it appeared in this session. Never guess a path. A wrong path is worse than none.
+- One risk has one home. If you already stated a risk in Assumptions or Limitations and ended it with a "Check: ..." action, move that action here and remove the "Check: ..." tail there, so the same action is not written twice.`
+    : '';
   return `add-reasoning-to-prs: before ${c.moment}, add a short, forward-only "why" block to ${c.where}, then re-run the command.${earlier}
 
 Write the block ONLY from what you actually decided in THIS session — never invent. Use only the sections that apply:
@@ -110,7 +128,7 @@ Write the block ONLY from what you actually decided in THIS session — never in
 - Decisions — the choices you made and why (not what changed; the diff already shows that).
 - Assumptions — what you took as given that a reviewer should confirm.
 - Trade-offs — what you knowingly gave up, and the option you rejected.
-- Limitations — known gaps or risks you are deliberately leaving.
+- Limitations — known gaps or risks you are deliberately leaving.${followupsBullet}
 
 How much to write:
 - Size the block to the change. Most PRs need one to three lines, not four full sections. A small or mechanical PR gets one line, or none.
@@ -122,7 +140,7 @@ Be honest:
 - Forward-only: capture what the diff can't show — the why, and the risks knowingly taken. Never summarize the changes.
 - Every line must trace to a real decision in this session. If the reason was never stated, drop the line — do not guess it.
 - Never restate the diff ("added X", "refactored Y"), and never pad with filler ("improves code quality", "various cleanups").
-- Write a caveat as a claim plus its silent consequence: "Assumes X; if X is wrong, Y breaks." A caveat with no named consequence is filler — cut it. End a risk with a short action, e.g. "Check: review both lists".
+- Write a caveat as a claim plus its silent consequence: "Assumes X; if X is wrong, Y breaks." A caveat with no named consequence is filler — cut it. End a risk with a short action, e.g. "Check: review both lists".${followupsGuidance}
 
 Write it plainly — the reviewer may not be a native English speaker:
 - One idea per sentence; prefer several short sentences over one long one with stacked clauses.
@@ -131,7 +149,7 @@ Write it plainly — the reviewer may not be a native English speaker:
 - Plain, factual, senior-engineer voice. No self-praise or marketing words (no "elegant", "robust", "clean", "seamless", "improves quality"). Say only what you decided and what is risky.
 
 Format:
-- Keep the four headings in this order; include only the non-empty ones.
+- Keep the headings in the order shown; include only the non-empty ones.
 - Wrap the block EXACTLY between the two markers below so it is detected and left untouched on later runs.
 - Add a visible attribution INSIDE the markers, scaled to the block. A substantial block uses the full attribution shown below (the heading/opening line plus the small closing note); a one- or two-line block uses only a single compact attribution line. Never a banner.
 

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -82,6 +82,9 @@ function exampleBlock(surface: Surface): string {
 /** Render accumulated (earlier-session) primitives as a plain, readable list. */
 function renderAccumulated(p: WhyPrimitives): string {
   const lines: string[] = [];
+  // Intentionally the four core PRIMITIVES only — the scratchpad never banks the PR-only
+  // `followups` (scratch.coercePrimitives loops PRIMITIVES), so an accumulated set can't
+  // carry one. If follow-ups ever become bankable, widen this to ALL_PRIMITIVES.
   for (const key of PRIMITIVES) {
     const items = (p[key] ?? []).filter(Boolean);
     if (items.length === 0) continue;
@@ -119,7 +122,7 @@ Recommended follow-ups (pull requests only):
 - Precision over coverage. If a careful reviewer could also reach the item by reading this diff, drop it. Most PRs have no follow-up. An empty section is the normal, correct outcome.
 - Exclude anything a normal code review, a linter, or CI already catches. This is not a review checklist.
 - Name the exact repository, file, or function only when it appeared in this session. Never guess a path. A wrong path is worse than none.
-- One risk has one home. If you already stated a risk in Assumptions or Limitations and ended it with a "Check: ..." action, move that action here and remove the "Check: ..." tail there, so the same action is not written twice.`
+- One risk has one home. Keep the inline "Check: ..." tail on a risk by default; only when that action is a cross-boundary follow-up you are promoting into this section, move it here and remove the "Check: ..." tail there — so the same action is never written twice.`
     : '';
   return `add-reasoning-to-prs: before ${c.moment}, add a short, forward-only "why" block to ${c.where}, then re-run the command.${earlier}
 

--- a/src/template.test.ts
+++ b/src/template.test.ts
@@ -44,3 +44,32 @@ test('empty primitives render nothing (leave-empty → omit the block)', () => {
   assert.equal(isEmptyBlock({ decisions: ['  ', ''] }), true);
   assert.equal(isEmptyBlock({ assumptions: ['real'] }), false);
 });
+
+test('Recommended follow-ups renders on the PR surface, after Limitations', () => {
+  const block = renderBlock('pr', {
+    limitations: ['left the backfill for a follow-up PR'],
+    followups: ['the mobile client still sends a legacy retryCount field the API no longer reads; drop it in apps/mobile/src/api.ts'],
+  });
+  assert.match(block, /\*\*Recommended follow-ups\*\*/);
+  assert.match(block, /- the mobile client still sends a legacy retryCount field/);
+  // Ordering: follow-ups come after limitations.
+  assert.ok(block.indexOf('Limitations') < block.indexOf('Recommended follow-ups'));
+});
+
+test('Recommended follow-ups NEVER renders on the commit surface', () => {
+  const block = renderBlock('commit', {
+    decisions: ['keep it local'],
+    followups: ['a cross-repo consequence a commit has no home for'],
+  });
+  assert.doesNotMatch(block, /Recommended follow-ups/);
+  assert.doesNotMatch(block, /cross-repo consequence/);
+  // The other sections still render normally.
+  assert.match(block, /Decisions:/);
+});
+
+test('a follow-up-only set renders on the PR surface but is empty on the commit surface', () => {
+  const followupOnly = { followups: ['applyDiscount duplicates the pricing branch order in the checkout service'] };
+  assert.match(renderBlock('pr', followupOnly), /\*\*Recommended follow-ups\*\*/);
+  assert.equal(renderBlock('commit', followupOnly), ''); // commit excludes follow-ups → nothing to render
+  assert.equal(isEmptyBlock(followupOnly), false); // but the set itself is not empty
+});

--- a/src/template.ts
+++ b/src/template.ts
@@ -16,9 +16,22 @@ import {
 /** Where a block lands: a PR description (markdown) or a commit message (plain text). */
 export type Surface = 'pr' | 'commit';
 
-/** The four forward-only primitives, in canonical render order. */
+/**
+ * The four forward-only primitives that render on EVERY surface, in canonical render order.
+ * (Recommended follow-ups is a fifth primitive, but it renders on the PR surface only — see
+ * PR_ONLY_PRIMITIVES — so it is kept out of this list, which callers treat as surface-neutral.)
+ */
 export const PRIMITIVES = ['decisions', 'assumptions', 'tradeoffs', 'limitations'] as const;
-export type PrimitiveKey = (typeof PRIMITIVES)[number];
+
+/**
+ * Primitives that render on the PR surface ONLY. A commit message is immutable once pushed
+ * and has no backlog/thread home, so a forward-looking to-do belongs on the review surface.
+ */
+export const PR_ONLY_PRIMITIVES = ['followups'] as const;
+
+/** Every primitive, in canonical render order (PR-only ones last). */
+export const ALL_PRIMITIVES = [...PRIMITIVES, ...PR_ONLY_PRIMITIVES] as const;
+export type PrimitiveKey = (typeof ALL_PRIMITIVES)[number];
 
 export interface WhyPrimitives {
   /** The choices made and why (not what changed — the diff shows that). */
@@ -29,6 +42,12 @@ export interface WhyPrimitives {
   tradeoffs?: string[];
   /** Known gaps, risks, or deliberately-deferred follow-ups. */
   limitations?: string[];
+  /**
+   * Forward-looking next steps the in-session reasoning surfaced that a reviewer could NOT
+   * get from this PR's diff alone (bias to cross-file / cross-repo / cross-service). PR
+   * surface only; kept deliberately rare (precision over coverage).
+   */
+  followups?: string[];
 }
 
 /** Human headings for each primitive (canonical wording). */
@@ -37,7 +56,13 @@ export const HEADINGS: Record<PrimitiveKey, string> = {
   assumptions: 'Assumptions',
   tradeoffs: 'Trade-offs',
   limitations: 'Limitations',
+  followups: 'Recommended follow-ups',
 };
+
+/** The primitives that render on a given surface, in canonical order. */
+export function primitivesForSurface(surface: Surface): readonly PrimitiveKey[] {
+  return surface === 'pr' ? ALL_PRIMITIVES : PRIMITIVES;
+}
 
 export function delimiters(surface: Surface): { open: string; close: string } {
   return surface === 'pr'
@@ -51,9 +76,11 @@ function clean(items: string[] | undefined): string[] {
   return items.map((s) => (typeof s === 'string' ? s.trim() : '')).filter(Boolean);
 }
 
-/** True if the primitives carry nothing worth recording (→ the block is omitted). */
+/** True if the primitives carry nothing worth recording (→ the block is omitted).
+ * Considers EVERY primitive (including the PR-only ones), so a set carrying only a
+ * follow-up still counts as non-empty. */
 export function isEmptyBlock(p: WhyPrimitives): boolean {
-  return PRIMITIVES.every((k) => clean(p[k]).length === 0);
+  return ALL_PRIMITIVES.every((k) => clean(p[k]).length === 0);
 }
 
 /**
@@ -65,11 +92,14 @@ export function isEmptyBlock(p: WhyPrimitives): boolean {
  * comments); commit messages render as plain text between sentinel lines.
  */
 export function renderBlock(surface: Surface, p: WhyPrimitives): string {
-  if (isEmptyBlock(p)) return '';
+  const keys = primitivesForSurface(surface);
+  // Emptiness is judged PER SURFACE: a follow-up-only set renders on the PR surface but is
+  // empty on the commit surface (which excludes follow-ups), so return '' there.
+  if (keys.every((k) => clean(p[k]).length === 0)) return '';
   const { open, close } = delimiters(surface);
   const isPr = surface === 'pr';
   const lines: string[] = [open];
-  for (const key of PRIMITIVES) {
+  for (const key of keys) {
     const items = clean(p[key]);
     if (items.length === 0) continue;
     lines.push(isPr ? `**${HEADINGS[key]}**` : `${HEADINGS[key]}:`);


### PR DESCRIPTION

<!-- backthread:why -->
## Reasoning
<sub>written by the agent in-session via [`backthread/add-reasoning-to-prs`](https://github.com/backthread/add-reasoning-to-prs)</sub>

**Decisions**
- Made `followups` a PR-only primitive through a per-surface primitive list (`primitivesForSurface`), not a global one. `renderBlock` judges emptiness per surface, so the commit message renders exactly as before and a follow-up-only set is empty on a commit but non-empty on a PR.
- Layered the stricter anti-padding bar as a follow-up-only filler list on top of the base scrub, rather than trying to judge "concreteness" generally. A syntactic rule cannot judge grounding, so the patterns are anchored — a concrete item that merely starts with a generic verb survives.

**Assumptions**
- Left the multi-session scratchpad on the four core primitives; it does not bank `followups`. This assumes follow-ups are authored by the PR-opening session from its own reasoning, not accumulated per-commit. If that is wrong, a `followups` key passed to `scratch add` is silently dropped by `coercePrimitives`.

<sub>↳ generated by [`backthread/add-reasoning-to-prs`](https://github.com/backthread/add-reasoning-to-prs) · an open-source Claude Code hook · edit or delete freely</sub>
<!-- /backthread:why -->
