### PR TITLE
Add a guarded, reproducible render for the social-preview card

### DIFF
--- a/assets/og-card.html
+++ b/assets/og-card.html
@@ -8,14 +8,30 @@
   nothing load-bearing is allowed to live in the outer 140px (sides) / 70px (top-bottom).
   Only the decorative full-bleed background and top accent bar are allowed past it.
 
-  Render (needs Google Chrome + JetBrains Mono installed), from the repo root:
-    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
-      --headless=new --disable-gpu --hide-scrollbars --force-device-scale-factor=1 \
-      --window-size=1280,640 --screenshot=assets/og-social-preview.png \
-      "file://$PWD/assets/og-card.html"
+  Render it from the repo root with:
+
+    ./assets/render-og.sh
+
+  which pins the window size and then asserts the three things that otherwise break
+  silently: JetBrains Mono is really installed (a fallback font changes every line
+  length), the PNG is exactly 1280x640, and no ink escapes the safe area above —
+  measured on rendered pixels, because this card's CSS height is not a clip.
 
   Then upload assets/og-social-preview.png in GitHub -> Settings -> General ->
-  Social preview. GitHub has no API for the social preview, so this upload is manual.
+  Social preview. There is no REST or GraphQL API for it, so that step is a browser
+  step — and it is the step that gets forgotten, so VERIFY IT FROM OUTSIDE GITHUB:
+
+    curl -sL https://github.com/backthread/add-reasoning-to-prs | grep -o 'og:image[^>]*'
+
+  A live custom card gives a repository-images.githubusercontent.com URL. An
+  opengraph.githubassets.com URL means GitHub's auto-generated fallback is still what
+  every X / Slack / LinkedIn link unfurls, and this file is decoration.
+
+  Legibility, measured by downscaling the render: unfurls render this at roughly
+  500px (X, LinkedIn), 360px (Slack) and 250px (small thumbnails). The 52px headline
+  and the repo name read at all three; the proof-card body copy is legible at 500px
+  and deliberately becomes texture below that, so the before/after contrast rides on
+  layout and colour, not on paragraph text. Anything load-bearing goes in the headline.
 -->
 <html>
 <head>

--- a/assets/render-og.sh
+++ b/assets/render-og.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# render-og.sh — render assets/og-card.html to assets/og-social-preview.png (1280x640),
+# the repo's social-preview (OG) card, and check the things that otherwise break silently.
+#
+#   ./assets/render-og.sh          # from the repo root
+#
+# Three failures this guards, all of which have actually happened or would go unnoticed:
+#
+#   1. A missing JetBrains Mono falls back to another monospace, quietly changing every
+#      line length and overflowing the proof cards. Asserted, not hoped for.
+#      Install from https://www.jetbrains.com/lp/mono/ (OFL-1.1).
+#   2. Headless Chrome happily writes a differently-sized PNG if the window flags drift.
+#      The output must be exactly 1280x640.
+#   3. Text drifting out of the centered 1000x500 safe area that unfurl surfaces crop
+#      toward. The card's own CSS height is NOT a clip, so containment can only be
+#      checked on rendered pixels — which is what the optional PIL step below does.
+#
+# UPLOADING IS A SEPARATE, MANUAL STEP, AND IT IS THE ONE THAT GETS FORGOTTEN.
+# GitHub exposes no REST or GraphQL API for the social preview, so:
+#      repo -> Settings -> General -> Social preview -> Upload an image
+# Then verify from OUTSIDE GitHub, because the settings dialog will happily show you a
+# preview of an upload that never took effect:
+#
+#   curl -sL https://github.com/backthread/add-reasoning-to-prs | grep -o 'og:image[^>]*'
+#
+# A custom card gives you a repository-images.githubusercontent.com URL. If you still see
+# opengraph.githubassets.com, that is GitHub's AUTO-GENERATED fallback and this card is
+# not live. (That is exactly how it sat un-uploaded for a month: the PNG was committed,
+# nothing ever checked the live tag.)
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+CARD="assets/og-card.html"
+OUT="assets/og-social-preview.png"
+CHROME="${CHROME:-/Applications/Google Chrome.app/Contents/MacOS/Google Chrome}"
+
+[ -f "$CARD" ] || { echo "error: $CARD not found (run from the repo root)" >&2; exit 1; }
+[ -x "$CHROME" ] || { echo "error: Chrome not found at '$CHROME'. Set CHROME=/path/to/chrome" >&2; exit 1; }
+
+# --- 1. the font must really be installed -------------------------------------------
+# Two independent probes; either finding it is enough. Note `grep -q` would SIGPIPE
+# fc-list and, under `set -o pipefail`, fail this check on a machine that HAS the font —
+# so count matches instead of short-circuiting.
+FOUND=0
+CHECKED=0
+if command -v fc-list >/dev/null 2>&1; then
+  CHECKED=1
+  FC_HITS="$(fc-list 2>/dev/null | grep -ci "jetbrains mono" || true)"
+  [ "${FC_HITS:-0}" -gt 0 ] && FOUND=1
+fi
+if [ "$FOUND" -eq 0 ] && [ "$(uname)" = "Darwin" ]; then
+  CHECKED=1
+  DIR_HITS="$(ls ~/Library/Fonts /Library/Fonts 2>/dev/null | grep -ci "JetBrainsMono" || true)"
+  [ "${DIR_HITS:-0}" -gt 0 ] && FOUND=1
+fi
+if [ "$FOUND" -eq 0 ]; then
+  if [ "$CHECKED" -eq 1 ]; then
+    echo "error: JetBrains Mono is not installed — the render would silently fall back." >&2
+    echo "       get it from https://www.jetbrains.com/lp/mono/ (OFL-1.1)" >&2
+    exit 1
+  fi
+  echo "warn: cannot verify JetBrains Mono is installed; check the output by eye" >&2
+fi
+
+# --- 2. render ----------------------------------------------------------------------
+"$CHROME" \
+  --headless=new --disable-gpu --hide-scrollbars --force-device-scale-factor=1 \
+  --window-size=1280,640 --screenshot="$OUT" \
+  "file://$PWD/$CARD" >/dev/null 2>&1
+
+[ -s "$OUT" ] || { echo "error: $OUT was not written" >&2; exit 1; }
+
+# --- 3. exact canvas size (GitHub's recommended social-preview size) ----------------
+DIMS=""
+if command -v sips >/dev/null 2>&1; then
+  DIMS="$(sips -g pixelWidth "$OUT" | awk '/pixelWidth/{w=$2} END{print w}')x$(sips -g pixelHeight "$OUT" | awk '/pixelHeight/{h=$2} END{print h}')"
+elif command -v file >/dev/null 2>&1; then
+  DIMS="$(file "$OUT" | grep -oE '[0-9]+ x [0-9]+' | head -1 | tr -d ' ')"
+fi
+if [ -n "$DIMS" ] && [ "$DIMS" != "1280x640" ]; then
+  echo "error: $OUT is ${DIMS}, expected 1280x640" >&2
+  exit 1
+fi
+
+# --- 4. safe-area containment, measured on pixels -----------------------------------
+# Optional: needs python3 + Pillow. Skipped loudly rather than silently.
+if python3 -c "import PIL" >/dev/null 2>&1; then
+  python3 - "$OUT" <<'PY' || exit 1
+import sys
+from PIL import Image
+
+PNG = sys.argv[1]
+SAFE = (140, 70, 1140, 570)          # centered 1000x500 box
+LUM_THRESHOLD = 25                    # above the decorative radial glow (~+8 lum)
+
+im = Image.open(PNG).convert("RGB")
+px = im.load()
+W, H = im.size
+lum = lambda p: 0.299 * p[0] + 0.587 * p[1] + 0.114 * p[2]
+bg = lum(px[5, H // 2])
+
+# skip the top 10px: the full-bleed accent bar is decorative and exempt by design
+minx, miny, maxx, maxy = W, H, -1, -1
+for y in range(10, H):
+    for x in range(W):
+        if abs(lum(px[x, y]) - bg) > LUM_THRESHOLD:
+            if x < minx: minx = x
+            if x > maxx: maxx = x
+            if y < miny: miny = y
+            if y > maxy: maxy = y
+
+if maxx < 0:
+    print("error: no ink found in %s — did the render come out blank?" % PNG, file=sys.stderr)
+    sys.exit(1)
+
+x0, y0, x1, y1 = SAFE
+ok = minx >= x0 and maxx <= x1 and miny >= y0 and maxy <= y1
+print("ink bbox x[%d,%d] y[%d,%d]; safe box x[%d,%d] y[%d,%d]" % (minx, maxx, miny, maxy, x0, x1, y0, y1))
+if not ok:
+    print("error: content escapes the 1000x500 safe area — it will be cropped in unfurls.", file=sys.stderr)
+    print("       overshoot: left %d right %d top %d bottom %d (negative = outside)"
+          % (minx - x0, x1 - maxx, miny - y0, y1 - maxy), file=sys.stderr)
+    sys.exit(1)
+print("safe-area margins: left %d right %d top %d bottom %d px" % (minx - x0, x1 - maxx, miny - y0, y1 - maxy))
+PY
+else
+  echo "warn: SKIPPED the safe-area containment check (needs python3 + Pillow: pip install Pillow)" >&2
+fi
+
+echo "rendered $OUT (${DIMS:-size unverified})"
+echo "next: GitHub -> Settings -> General -> Social preview -> Upload an image,"
+echo "      then verify the live tag:  curl -sL https://github.com/backthread/add-reasoning-to-prs | grep -o 'og:image[^>]*'"


### PR DESCRIPTION
## What

Adds `assets/render-og.sh` — a reproducible, guarded render of the social-preview card — and points `og-card.html`'s header comment at it. **No pixels change:** re-rendering from the committed HTML reproduces the committed PNG byte for byte (identical sha256).

## Why

The card's PNG and its HTML source were both already committed. What was missing was (a) a repeatable way to render it and (b) any way to notice when something silently went wrong. Three failure modes, all quiet:

| Failure | Why it is quiet | Guard |
|---|---|---|
| JetBrains Mono not installed | Falls back to another monospace, changing every line length and overflowing the proof cards | Two independent font probes, asserted before rendering |
| Window flags drift | Chrome cheerfully writes a differently-sized PNG | Output must be exactly 1280x640 |
| Text escapes the centered 1000x500 safe area | The `.safe` wrapper is **not** `overflow:hidden`, so its CSS height never clips anything — the arithmetic can look right while pixels sit outside | Ink bounding box measured on the rendered PNG |

The containment check needs Pillow. If it is unavailable the script says **SKIPPED** loudly rather than passing quietly.

## Guards were mutation-tested, not assumed

Each check was run against a deliberate mutant in a throwaway copy of `assets/`:

| Mutant | Expected | Result |
|---|---|---|
| Font name changed to one that does not exist (both probes) | fail, and write no PNG | exit 1, no output file |
| `--window-size=900,500` | fail on dimensions | exit 1 — `is 900x500, expected 1280x640` |
| `.safe{left:170px}` -> `left:20px` | fail on containment | exit 1 — `ink bbox x[57,922]`, `overshoot: left -83` |
| Content hidden entirely | fail on the blank-render branch | exit 1 — `no ink found` |
| **Unmutated control** | pass | exit 0 |

Measured on the current card: ink bbox `x[207,1072] y[80,542]` inside the safe box `x[140,1140] y[70,570]` — margins left 67, right 68, top 10, bottom 28 px. The earlier full-canvas measurement that appeared to fail was picking up the decorative radial glow, which the source explicitly exempts from the safe area; raising the luminance threshold above the glow (~+8) isolates real ink.

## The part that actually mattered

The social preview has **no REST or GraphQL API** — uploading it is a browser step, and the settings dialog shows a preview whether or not it took effect. So the header comment now records the only honest check:

```sh
curl -sL https://github.com/backthread/add-reasoning-to-prs | grep -o 'og:image[^>]*'
```

A `repository-images.githubusercontent.com` URL means the custom card is live. An `opengraph.githubassets.com` URL means GitHub's auto-generated fallback is still what every X / Bluesky / Slack / LinkedIn link unfurls. That missing check is precisely how the card sat committed in this repo without ever being served.

Also recorded: how the card reads downscaled (500px / 360px / 250px). The 52px headline and the repo name read at all three; body copy is legible at 500px and deliberately becomes texture below it, so the before/after contrast rides on layout and colour. Anything load-bearing belongs in the headline.
