### PR TITLE
Give every CI gate its own job, and fix a guard that could not fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,37 @@
 # CI — typecheck + test on every PR and push to main, verify the committed self-contained
-# bundle is in sync with src, and hold the supply-chain floor for a widely-`npx`'d
-# package: a vulnerability gate, a lockfile-integrity gate, and a guard that the release
-# keeps npm provenance on.
+# bundle is in sync with src, drive the built bundle end-to-end, and hold the supply-chain
+# floor for a widely-`npx`'d package: a vulnerability gate, a lockfile-integrity gate, and
+# a guard that the release keeps npm provenance on.
+#
+# EVERY GATE IS ITS OWN JOB, ON PURPOSE. These used to be sequential steps in one job, so the
+# FIRST failure skipped every later step. The vulnerability gate sat fourth, ahead of typecheck,
+# the tests, the bundle-sync check and the E2E dogfood gate — so a single dev-only advisory
+# anywhere in the tree would have meant a PR got NO signal about its own change, and the E2E gate,
+# being last, had the most to lose. The advisory tree is clean today, which made that latent rather
+# than harmless: it is one dependabot bump away from a total blackout. The sibling monorepo hit
+# exactly this and measured it — 9 of 12 red runs there never ran the tests at all.
+#
+# Each job carries `timeout-minutes` because a hung gate is the one failure mode that costs more
+# than a red one: GitHub's default is 6 hours of runner time with no report at the end.
+#
+# WHY THE TEST SCRIPT PASSES `--experimental-test-isolation=none`. By default `node --test` forks
+# one child process per test file, and each child reports back by writing v8-serialized frames to
+# its STDOUT; the parent rebuilds the report by sniffing that stream for a two-byte frame header.
+# That framing is fragile, and when it goes wrong the parent reports
+# `uncaughtException: Unable to deserialize cloned data due to invalid or unsupported version.` at
+# `#processRawBuffer (node:internal/test_runner/runner)` against an arbitrary test file whose own
+# subtests all passed — a red run, an innocent file, and nothing learned about the diff. Measured
+# in the sibling monorepo on a runner, 10 interleaved runs per arm: the forked mode failed 3/10,
+# every one that error and none an assertion; in-process 0/10. It never reproduced on a developer
+# machine. In-process there is no child, no pipe and no framing, so the failure mode stops existing
+# rather than getting rarer. `release.yml` runs the same `npm test` before `npm publish`, which is
+# why the flag lives in the package script and not here.
+#
+# WHAT THE FLAG COSTS, measured rather than assumed: a module-level `throw` is red in both modes
+# only if it precedes the file's FIRST test registration. After that, in-process exits 0 with
+# `# fail 0` and silently drops the remaining tests from the count. The pass-count floor in the
+# test job is the mitigation — the case where tests actually stop running drops the count, so the
+# floor turns it back into a red.
 #
 # GitHub Actions are PINNED BY COMMIT SHA (not a floating tag) so a compromised/retagged
 # action can't silently run in CI; Dependabot (.github/dependabot.yml) proposes bumps.
@@ -13,46 +43,152 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  # The checks that need no dependency install, so no advisory and no drifted lockfile can stop
+  # them running. One step with `|| rc=1` rather than two steps, because steps in a job are
+  # sequential and would reproduce the same blackout in miniature.
+  guards:
+    name: Lockfile + release guards
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+      - name: Every guard runs, then the job fails if any of them did
+        run: |
+          rc=0
+
+          # Lockfile integrity: it must be present, and `npm ci` (in every other job) hard-fails
+          # if it's out of sync with package.json — so an un-committed dependency change can't
+          # slip through.
+          echo "::group::Lockfile present"
+          test -f package-lock.json \
+            || { echo "::error::package-lock.json is missing — commit it (npm install)."; rc=1; }
+          echo "::endgroup::"
+
+          # Every `npm publish` must keep provenance on, so each published package carries a
+          # verifiable, tamper-evident build attestation. This was a one-line grep until it was
+          # measured: `npm publish[^#]*--provenance` forbids a `#` BETWEEN the tokens but not
+          # BEFORE them, and release.yml carries a comment reading "`npm publish --provenance`
+          # (its bundled libnpmpublish can't resolve sigstore)". That comment satisfied the
+          # pattern unconditionally, so the check COULD NOT FAIL — verified by deleting
+          # --provenance from the real publish step and watching it stay green. The same defect
+          # was found and fixed in the sibling monorepo; scripts/check-provenance.mjs is the
+          # shared shape, and it checks every workflow rather than the ones we remembered to glob.
+          echo "::group::Every npm publish keeps provenance on"
+          node scripts/check-provenance.mjs || rc=1
+          echo "::endgroup::"
+
+          exit $rc
+
+  # Its own job: an advisory is a fact about the dependency tree, not about the diff, and it must
+  # never again be the reason the diff went unchecked.
+  audit:
+    name: Vulnerability gate (npm audit, high+)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
-      # Lockfile integrity: it must be present, and `npm ci` (below) hard-fails if it's
-      # out of sync with package.json — so an un-committed dependency change can't slip
-      # through.
-      - name: Lockfile present
-        run: test -f package-lock.json || { echo "::error::package-lock.json is missing — commit it (npm install)."; exit 1; }
+      - run: npm audit --audit-level=high
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
       - name: Install (npm ci — fails on a drifted lockfile)
         run: npm ci
-      # Vulnerability gate: fail the build on a HIGH+ advisory anywhere in the tree.
-      - name: Vulnerability gate (npm audit, high+)
-        run: npm audit --audit-level=high
-      - name: Typecheck
-        run: npm run typecheck
-      # `npm test` runs the unit suite + `npm run build` + `npm run smoke`, and the smoke
-      # step regenerates dist-bundle/add-reasoning-to-prs.js — so the sync check below
-      # compares the committed bundle against a fresh build.
-      - name: Test
-        run: npm test
-      # The Claude Code plugin is cloned from git with NO build step on install, so the
-      # COMMITTED bundle must equal a fresh build. `npm test` just rebuilt it; fail if it
-      # differs from what's committed (esbuild is deterministic for the pinned version).
-      - name: Committed bundle is in sync with src
-        run: git diff --exit-code dist-bundle/add-reasoning-to-prs.js
-      # End-to-end dogfood gate: drive the built bundle through every path (PR + direct-push
-      # surfaces, idempotency, empty/anti-loop cap, off-switch, skip, scratchpad, fail-open,
-      # never-hard-blocks) against a throwaway git repo.
-      - name: E2E dogfood validation
-        run: npm run e2e
-      # Regression guard: every release workflow must keep npm build provenance on, so
-      # each published package always carries a verifiable, tamper-evident attestation.
-      - name: Releases keep npm provenance on
+      - run: npm run typecheck
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install (npm ci — fails on a drifted lockfile)
+        run: npm ci
+      # `tee` + a pass-count FLOOR, not just the exit code. `node --test` exits 0 when its glob
+      # matches nothing, and in-process isolation swallows a module-level throw once any test in
+      # that file has registered — either way the job would go green having run less than it
+      # should. `pipefail` so `tee` cannot mask npm's exit status.
+      - name: npm test, then hold it to its pass-count floor
+        shell: bash
         run: |
-          for wf in .github/workflows/release*.yml; do
-            grep -Eq 'npm publish[^#]*--provenance' "$wf" \
-              || { echo "::error::$wf's npm publish must keep --provenance"; exit 1; }
-          done
+          set -o pipefail
+          npm test 2>&1 | tee test-output.txt
+          node scripts/check-test-floor.mjs --min=76 test-output.txt
+      # PROVE THE FLOOR CAN FAIL, on this runner, on this commit — both of its paths. The count
+      # path is the one people picture; the FAIL-CLOSED path matters more, because if a runner ever
+      # renames its `# pass N` summary the only thing between that and a green tick is this script
+      # choosing to exit 1 on a log it could not parse. `if: success()` deliberately: this exists
+      # to catch a run that went GREEN having executed too little, so on an already-red run it
+      # could only add a second error a layer from the cause.
+      - name: Self-test — the floor can fail
+        if: success()
+        shell: bash
+        run: |
+          if node scripts/check-test-floor.mjs --min=999999 test-output.txt; then
+            echo "::error::the floor passed against an impossible minimum, so it is vacuous"
+            exit 1
+          fi
+          echo "ok — the floor rejects a count below its minimum"
+          : > empty.txt
+          if node scripts/check-test-floor.mjs --min=1 empty.txt; then
+            echo "::error::the floor passed on a log with NO summary — it must fail closed"
+            exit 1
+          fi
+          echo "ok — a log with no summary is a failure, not a pass"
+
+  # The Claude Code plugin is cloned from git with NO build step on install, so the COMMITTED
+  # bundle must equal a fresh build (esbuild is deterministic for the pinned version). This used to
+  # piggyback on `npm test` having rebuilt the bundle, which meant a single failing test also
+  # silenced it; it now builds the bundle itself and answers only for the sync question.
+  bundle-sync:
+    name: Committed bundle is in sync with src
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install (npm ci — fails on a drifted lockfile)
+        run: npm ci
+      - name: Rebuild the bundle from src
+        run: npm run bundle
+      - run: git diff --exit-code dist-bundle/add-reasoning-to-prs.js
+
+  # End-to-end dogfood gate: drive the built bundle through every path (PR + direct-push surfaces,
+  # idempotency, empty/anti-loop cap, off-switch, skip, scratchpad, fail-open, never-hard-blocks)
+  # against a throwaway git repo. It was the LAST step of the old single job, so it was the first
+  # thing lost to any earlier failure — and it is the only gate that exercises the artefact users
+  # actually run.
+  e2e:
+    name: E2E dogfood validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install (npm ci — fails on a drifted lockfile)
+        run: npm ci
+      - run: npm run e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,25 +130,27 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          npm test 2>&1 | tee test-output.txt
-          node scripts/check-test-floor.mjs --min=76 test-output.txt
+          npm test 2>&1 | tee "$RUNNER_TEMP/test-output.txt"
+          node scripts/check-test-floor.mjs --min=76 "$RUNNER_TEMP/test-output.txt"
       # PROVE THE FLOOR CAN FAIL, on this runner, on this commit — both of its paths. The count
       # path is the one people picture; the FAIL-CLOSED path matters more, because if a runner ever
       # renames its `# pass N` summary the only thing between that and a green tick is this script
-      # choosing to exit 1 on a log it could not parse. `if: success()` deliberately: this exists
-      # to catch a run that went GREEN having executed too little, so on an already-red run it
-      # could only add a second error a layer from the cause.
+      # choosing to exit 1 on a log it could not parse. Scratch files live in `$RUNNER_TEMP`,
+      # outside the checkout, so they can never become a phantom diff for a working-tree check.
+      # `if: success()` deliberately: this exists to catch a run that went GREEN having executed
+      # too little, so on an already-red run it could only add a second error a layer from the
+      # cause.
       - name: Self-test — the floor can fail
         if: success()
         shell: bash
         run: |
-          if node scripts/check-test-floor.mjs --min=999999 test-output.txt; then
+          if node scripts/check-test-floor.mjs --min=999999 "$RUNNER_TEMP/test-output.txt"; then
             echo "::error::the floor passed against an impossible minimum, so it is vacuous"
             exit 1
           fi
           echo "ok — the floor rejects a count below its minimum"
-          : > empty.txt
-          if node scripts/check-test-floor.mjs --min=1 empty.txt; then
+          : > "$RUNNER_TEMP/empty.txt"
+          if node scripts/check-test-floor.mjs --min=1 "$RUNNER_TEMP/empty.txt"; then
             echo "::error::the floor passed on a log with NO summary — it must fail closed"
             exit 1
           fi

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "start": "tsx src/bin/add-reasoning-to-prs.ts",
     "smoke": "npm run bundle && node dist-bundle/add-reasoning-to-prs.js --version > /dev/null",
-    "test": "node --import tsx --test --test-force-exit src/*.test.ts && npm run build && npm run smoke",
+    "test": "node --import tsx --test --experimental-test-isolation=none --test-force-exit src/*.test.ts && npm run build && npm run smoke",
     "e2e": "npm run bundle && bash scripts/e2e.sh"
   },
   "engines": {
@@ -52,5 +52,6 @@
     "esbuild": "^0.28.0",
     "tsx": "^4.22.3",
     "typescript": "^5.6.2"
-  }
+  },
+  "comment_test_isolation": "`--experimental-test-isolation=none` avoids a Node test-runner crash in the forked mode that reddened CI at random; full reasoning in .github/workflows/ci.yml."
 }

--- a/scripts/check-provenance.mjs
+++ b/scripts/check-provenance.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+// Guard: every `npm publish` this repo can perform must carry `--provenance`, so each published
+// package always ships a verifiable, tamper-evident build attestation.
+//
+// This replaces a one-line grep that could not fail, and then could still be fooled four ways.
+// The history is worth keeping, because each step is a lesson about what a guard actually checks:
+//
+//   1. `grep -Eq 'npm publish[^#]*--provenance' "$wf"` — `[^#]*` forbids a `#` BETWEEN the tokens
+//      but not BEFORE them, and both release workflows contain a comment reading "`npm publish
+//      --provenance` with Cannot find module sigstore". That comment satisfied the pattern
+//      unconditionally, so the check could not fail at all. Measured: deleting `--provenance`
+//      from the real publish step left it green.
+//   2. Anchoring at `^[^#]*` fixed that, and left four holes, all measured:
+//        • a step `name:` carrying the tokens satisfied it while the `run:` below dropped the flag
+//          — the original defect one line up;
+//        • `--provenance=false` passed, because a substring is not a value;
+//        • a SECOND publish step with no flag passed, because `grep -q` stops at the first hit;
+//        • renaming `release-extractor.yml` to `publish-extractor.yml` escaped the glob entirely,
+//          which is exactly what the old comment claimed could not happen.
+//
+// So it is checked as a closed allowlist over EVERY workflow, not a glob over the ones we
+// remember: find every `npm publish` in `.github/workflows/*.yml`, on a `run:` line only, and
+// require each one to carry `--provenance` with no falsy value. A publish outside a `release*.yml`
+// is refused outright rather than silently unguarded.
+//
+// Dependency-free: it runs in the CI job that does no install.
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const WORKFLOW_DIR = join(ROOT, '.github/workflows');
+
+let failed = false;
+function error(message) {
+  console.error(`::error::${message}`);
+  failed = true;
+}
+
+/**
+ * Strip a YAML comment from a line, tracking quotes so a `#` inside a string survives.
+ * A commented-out publish step is not a publish step, and must not be able to satisfy — or to
+ * trip — this guard.
+ */
+function withoutComment(line) {
+  let quote = null;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+    } else if (ch === "'" || ch === '"') {
+      quote = ch;
+    } else if (ch === '#') {
+      return line.slice(0, i);
+    }
+  }
+  return line;
+}
+
+/**
+ * Whether this line is executable shell rather than YAML metadata. A step's `name:` is prose and
+ * must never be able to satisfy the guard on behalf of the `run:` beneath it; inside a `run: |`
+ * block every line is shell, so the block is tracked by indentation.
+ */
+function executableLines(text) {
+  const out = [];
+  let blockIndent = null;
+  for (const raw of text.split('\n')) {
+    const line = withoutComment(raw);
+    if (line.trim() === '') continue;
+    const indent = line.length - line.trimStart().length;
+    if (blockIndent !== null) {
+      if (indent > blockIndent) {
+        out.push(line);
+        continue;
+      }
+      blockIndent = null;
+    }
+    const runBlock = line.match(/^(\s*)-?\s*run:\s*[|>][-+]?\s*$/);
+    if (runBlock) {
+      blockIndent = runBlock[1].length;
+      continue;
+    }
+    const runInline = line.match(/^\s*-?\s*run:\s*(.+)$/);
+    if (runInline) out.push(runInline[1]);
+  }
+  return out;
+}
+
+/**
+ * A shell line with quoted string CONTENTS removed, so prose cannot be mistaken for a command.
+ * `echo "::group::Every npm publish keeps provenance on"` is not a publish step, and an earlier
+ * version of this guard failed its own repo on exactly that line — a guard that cries wolf gets
+ * switched off, which is the same outcome as one that cannot fail.
+ */
+function withoutQuotedStrings(line) {
+  let out = '';
+  let quote = null;
+  for (const ch of line) {
+    if (quote) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}
+
+const workflows = readdirSync(WORKFLOW_DIR).filter((f) => /\.ya?ml$/.test(f));
+if (workflows.length === 0) {
+  error('.github/workflows contains no workflow files — refusing to report a vacuous pass');
+}
+
+let publishSteps = 0;
+for (const file of workflows) {
+  const text = readFileSync(join(WORKFLOW_DIR, file), 'utf8');
+  for (const rawLine of executableLines(text)) {
+    const line = withoutQuotedStrings(rawLine);
+    if (!/\bnpm publish\b/.test(line)) continue;
+    publishSteps++;
+    if (!/^release/.test(file)) {
+      error(
+        `.github/workflows/${file} runs \`npm publish\` but is not a release*.yml — publish paths ` +
+          'must be named release*.yml so every guard that globs them applies here too',
+      );
+    }
+    if (!/--provenance(?![=\w])/.test(line) && !/--provenance=true\b/.test(line)) {
+      error(
+        `.github/workflows/${file}: this \`npm publish\` does not carry \`--provenance\` (or sets ` +
+          `it falsy), so the package would ship without a build attestation:\n    ${rawLine.trim()}`,
+      );
+    }
+  }
+}
+
+// A release workflow that publishes nothing is fine; ZERO publish steps across the whole repo is
+// not something to silently pass, because it means this guard verified nothing.
+if (publishSteps === 0) {
+  error(
+    'found no `npm publish` in any workflow. If publishing moved, point this guard at the new ' +
+      'path; do not leave it passing over nothing.',
+  );
+}
+
+if (failed) process.exit(1);
+console.log(`OK — all ${publishSteps} \`npm publish\` step(s) carry --provenance, and all live in release*.yml`);

--- a/scripts/check-test-floor.mjs
+++ b/scripts/check-test-floor.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// Guard: the suite must report at least `--min` PASSING tests.
+//
+// Why a count and not just the exit code: the test script runs with
+// `--experimental-test-isolation=none` (see .github/workflows/ci.yml), and that mode SWALLOWS a
+// module-level throw once any test in the file has registered — the run exits 0 with `# fail 0`
+// and quietly reports fewer tests. `npm test` is happy, the gate is green, and tests have stopped
+// running. A floor is the only thing that separates "everything passed" from "less of it ran".
+// `node --test` also exits 0 when its glob matches nothing, so a rename under `src/` would
+// otherwise turn the job into a green tick over an empty room.
+//
+// FAIL-CLOSED: a missing, unreadable or unparsable log is a failure, never a pass. "I could not
+// tell" and "it passed" must not share an exit code.
+//
+// Usage:  node scripts/check-test-floor.mjs --min=<n> <path-to-test-output>
+
+import { readFileSync } from 'node:fs';
+
+function fail(message) {
+  console.error(`::error::${message}`);
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const minArg = args.find((a) => a.startsWith('--min='));
+const outputPath = args.find((a) => !a.startsWith('--'));
+if (!minArg || !outputPath) fail('usage: check-test-floor.mjs --min=<n> <output-file>');
+
+const min = Number(minArg.slice('--min='.length));
+if (!Number.isInteger(min) || min < 1) fail(`--min must be a positive integer, got "${minArg}"`);
+
+let output;
+try {
+  output = readFileSync(outputPath, 'utf8');
+} catch {
+  fail(`could not read the test output at ${outputPath} — refusing to assume the suite passed`);
+}
+
+const passes = [...output.matchAll(/^# pass (\d+)$/gm)].map((m) => Number(m[1]));
+if (passes.length === 0) {
+  fail(
+    `found no \`# pass N\` line in ${outputPath} — the suite did not report, so this gate cannot ` +
+      'say anything about it. If the runner renamed its summary, fix this script; do not drop it.',
+  );
+}
+const total = passes.reduce((a, b) => a + b, 0);
+
+if (total < min) {
+  fail(
+    `the suite reported ${total} passing test(s), below its floor of ${min}. Either tests stopped ` +
+      'running (a module-level throw is swallowed silently in this mode, and an unmatched glob ' +
+      'exits 0) or they were removed deliberately — in which case lower the floor here and say why.',
+  );
+}
+
+console.log(`OK — ${total} passing test(s), floor ${min}`);


### PR DESCRIPTION
Companion to the same three fixes in the `backthread` monorepo. Everything here was measured on this repo, not carried over on faith.

## 1. One job of sequential steps, so the first failure skipped the rest

The old order was `Lockfile → npm ci → audit → Typecheck → Test → bundle-sync → E2E → provenance`. A failure at any point skipped everything after it, and the **vulnerability gate sat fourth** — ahead of every check that says anything about the diff.

`npm audit --audit-level=high` reports `found 0 vulnerabilities` today, so this is **latent, not harmless**: it is one dependabot bump away from a PR carrying no signal at all. The sibling monorepo had exactly this shape and measured the consequence — **9 of 12 red runs there never ran the tests**, and the blocking gate simply moved down the list as each cause was fixed. That is why this is a split and not a reorder: a reorder only chooses a different single point of failure.

This repo had *more* to lose than the monorepo, because **`npm run e2e` was last** — the only gate that drives the artefact users actually run.

Now six independent jobs, each with a `timeout-minutes` (a hung gate is the one failure that costs more than a red one: six hours of runner time and no report):

`Lockfile + release guards` · `Vulnerability gate` · `Typecheck` · `Test` · `Committed bundle is in sync with src` · `E2E dogfood validation`

The two install-free checks share one job so no advisory can stop them, and they are **one step with `|| rc=1`** rather than two steps, because steps in a job are sequential and would reproduce the same blackout in miniature.

## 2. The provenance guard could not fail

```
grep -Eq 'npm publish[^#]*--provenance' "$wf"
```

`[^#]*` forbids a `#` *between* the two tokens, not *before* them — and `release.yml:52` reads:

```
# `npm publish --provenance` (its bundled libnpmpublish can't resolve sigstore).
```

That comment satisfied the pattern unconditionally. **Verified by deleting `--provenance` from the real publish step on line 75: the old grep still passed.** The check has never been able to fail.

Replaced with `scripts/check-provenance.mjs`, which walks **every** workflow, considers only executable `run:` lines with quoted prose stripped, requires the flag on **every** publish it finds, rejects `--provenance=false`, and refuses a publish outside `release*.yml` rather than leaving it silently unguarded. Mutations, all now caught: flag stripped · `--provenance=false` · workflow renamed out of the `release*` glob. The legitimate forms still pass.

For the avoidance of doubt on the published artefact: the flag was genuinely present in `release.yml` the whole time, so nothing shipped without provenance. What was broken was the ability to notice if it ever stopped.

## 3. The test runner was not trustworthy, and the fix has a cost that is now guarded

`node --test` forks one child per test file; each child reports by writing v8-serialized frames to **stdout**, and the parent rebuilds the report by sniffing that stream for a two-byte header. When it misframes, the parent reports `uncaughtException: Unable to deserialize cloned data due to invalid or unsupported version.` at `#processRawBuffer` against a file whose own subtests all passed. Measured on a runner in the sibling repo, 10 interleaved runs per arm: **forked 3/10 failed, every one that error and none an assertion; in-process 0/10.** Never reproducible on a developer machine. `--experimental-test-isolation=none` removes the child, the pipe and the framing, so the failure mode stops existing rather than getting rarer.

It is set in the **package script**, not the workflow, because `release.yml` runs the same `npm test` before `npm publish` — one edit fixes CI, the release path and a contributor's terminal.

**The cost, measured:** in-process swallows a module-level `throw` once any test in that file has registered — the run exits 0 with `# fail 0` and simply reports fewer tests. `node --test` also already exited 0 on a glob matching nothing. So the test job now holds the suite to a **pass-count floor**:

> injected a mid-file `throw` into `src/bodyFile.test.ts` → `npm test` **exits 0** reporting **74 of 76** passing tests → the floor fails the job and names the cause.

The floor **fails closed** — a missing, unreadable or unparsable log is a failure, never a pass — and the job then **proves the floor can fail on this runner, on this commit**, against both an impossible minimum *and* a log with no summary at all. Both paths, because if a runner ever renames its `# pass N` summary, the only thing between that and a green tick is this script choosing to exit 1 on something it could not parse.

## Verified locally, every job

| gate | result |
|---|---|
| provenance guard | `OK — all 1 npm publish step(s) carry --provenance` |
| typecheck | clean |
| test + floor | `# pass 76 / # fail 0`, `OK — 76 passing test(s), floor 76` |
| bundle-sync | fresh build byte-identical to the committed bundle |
| e2e | `== 19 passed, 0 failed ==` |
| floor negative controls | impossible minimum, empty log, and missing file all rejected |
