### PR TITLE
The denial could turn the block into the whole description, and said nothing

### DIFF
--- a/dist-bundle/add-reasoning-to-prs.js
+++ b/dist-bundle/add-reasoning-to-prs.js
@@ -419,10 +419,26 @@ var PACKAGE_URL = "https://github.com/backthread/add-reasoning-to-prs";
 function surfaceCopy(surface) {
   return surface === "pr" ? {
     moment: "this pull request is opened",
-    where: "the pull request description (the --body / --body-file text)"
+    where: "the pull request description (the --body / --body-file text)",
+    // WHY THIS WARNING EXISTS. This denial blocks the WHOLE tool call. If that call
+    // both wrote the body file and ran `gh pr create` — a heredoc chained to the
+    // command, which is a common shape — then the file was never written. The obvious
+    // repair ("add the block and re-run") then appends with `>>` to a file that does
+    // not exist, creating one that holds ONLY the block. `gh pr create` succeeds, and
+    // the pull request opens with the reasoning block as its entire description.
+    // Nothing reports an error at any step.
+    //
+    // Measured on two real pull requests before this warning existed: both shipped
+    // with a single character outside the markers. The block is meant to be an
+    // ADDITION to the description, never a replacement, so a denial that silently
+    // produces the replacement defeats the tool.
+    rerunTrap: "\n\n\u26A0 Before you re-run: this denial blocked the ENTIRE command. If that same command also wrote the body file (for example a heredoc and `gh pr create` in one shell call), the file was never written. Appending the block with `>>` will then create a file that holds ONLY the block, and the pull request will open with the block as its whole description \u2014 with no error anywhere.\nWrite the body file in a SEPARATE command from `gh pr create`, and check the file is the size you expect before creating. The block is an addition to the description, never a replacement for it."
   } : {
     moment: "this commit lands on the default branch",
-    where: "the commit message body"
+    where: "the commit message body",
+    // No equivalent trap: a commit message is re-authored on the retry, so a blocked
+    // call cannot leave a half-written artifact behind.
+    rerunTrap: ""
   };
 }
 function attributionHeader(surface) {
@@ -515,7 +531,7 @@ Self-check BEFORE you write \u2014 a quick grounded pass, no tools or network ne
 - Take each candidate line and name the specific point in THIS session where that decision, assumption, trade-off, or limitation actually came up. If you can't point to one, delete the line.
 - If nothing survives, there is no block to add: re-run your original command unchanged, or add ${SKIP_TOKEN} to it to opt out explicitly. Never manufacture filler \u2014 an empty block is the correct outcome for a session that didn't deliberate.
 
-Otherwise, re-run your original command with the surviving block included in ${c.where}.`;
+Otherwise, re-run your original command with the surviving block included in ${c.where}.${c.rerunTrap}`;
 }
 function buildScratchNudge() {
   return `add-reasoning-to-prs: you're committing on a feature branch, so this commit isn't touched. If this chunk of work involved a notable decision, assumption, trade-off, or limitation, bank it now \u2014 the eventual PR's why-block will fold it in, even if a different session opens the PR:

--- a/src/guidance.test.ts
+++ b/src/guidance.test.ts
@@ -83,3 +83,24 @@ test('commit-surface attribution is plain text (no markdown heading, HTML, or li
   assert.doesNotMatch(commit, /## Reasoning/); // a commit message doesn't render markdown
   assert.doesNotMatch(commit, /<sub>/);
 });
+
+// The block is an ADDITION to the description, never a replacement. The denial blocks the
+// whole tool call, so a call that both wrote the body file and ran `gh pr create` leaves no
+// file behind — and the natural repair (`>>` the block, re-run) then creates a file holding
+// only the block. Two real pull requests shipped that way before this warning existed, with
+// a single character outside the markers and no error at any step.
+test('PR guidance warns that re-running can lose a body written in the same command', () => {
+  const pr = buildGuidance('pr');
+  assert.match(pr, /blocked the ENTIRE command/i);
+  assert.match(pr, /SEPARATE command/i);
+  assert.match(pr, /addition to the description, never a replacement/i);
+});
+
+// Not a blanket warning: a commit message is re-authored on the retry, so there is no
+// half-written artifact to lose. Asserting its ABSENCE is what keeps the PR-only warning
+// from quietly becoming boilerplate on every surface.
+test('commit guidance carries no body-file warning, because it has no such trap', () => {
+  const commit = buildGuidance('commit');
+  assert.doesNotMatch(commit, /blocked the ENTIRE command/i);
+  assert.doesNotMatch(commit, /--body-file/i);
+});

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -27,6 +27,11 @@ const PACKAGE_URL = 'https://github.com/backthread/add-reasoning-to-prs';
 interface SurfaceCopy {
   moment: string;
   where: string;
+  /**
+   * A trap this denial can walk the model into, if re-running is not as simple as it
+   * sounds. Empty for surfaces that have none. See `rerunTrap` below for the PR case.
+   */
+  rerunTrap: string;
 }
 
 function surfaceCopy(surface: Surface): SurfaceCopy {
@@ -34,10 +39,27 @@ function surfaceCopy(surface: Surface): SurfaceCopy {
     ? {
         moment: 'this pull request is opened',
         where: 'the pull request description (the --body / --body-file text)',
+        // WHY THIS WARNING EXISTS. This denial blocks the WHOLE tool call. If that call
+        // both wrote the body file and ran `gh pr create` — a heredoc chained to the
+        // command, which is a common shape — then the file was never written. The obvious
+        // repair ("add the block and re-run") then appends with `>>` to a file that does
+        // not exist, creating one that holds ONLY the block. `gh pr create` succeeds, and
+        // the pull request opens with the reasoning block as its entire description.
+        // Nothing reports an error at any step.
+        //
+        // Measured on two real pull requests before this warning existed: both shipped
+        // with a single character outside the markers. The block is meant to be an
+        // ADDITION to the description, never a replacement, so a denial that silently
+        // produces the replacement defeats the tool.
+        rerunTrap:
+          '\n\n⚠ Before you re-run: this denial blocked the ENTIRE command. If that same command also wrote the body file (for example a heredoc and `gh pr create` in one shell call), the file was never written. Appending the block with `>>` will then create a file that holds ONLY the block, and the pull request will open with the block as its whole description — with no error anywhere.\nWrite the body file in a SEPARATE command from `gh pr create`, and check the file is the size you expect before creating. The block is an addition to the description, never a replacement for it.',
       }
     : {
         moment: 'this commit lands on the default branch',
         where: 'the commit message body',
+        // No equivalent trap: a commit message is re-authored on the retry, so a blocked
+        // call cannot leave a half-written artifact behind.
+        rerunTrap: '',
       };
 }
 
@@ -162,7 +184,7 @@ Self-check BEFORE you write — a quick grounded pass, no tools or network neede
 - Take each candidate line and name the specific point in THIS session where that decision, assumption, trade-off, or limitation actually came up. If you can't point to one, delete the line.
 - If nothing survives, there is no block to add: re-run your original command unchanged, or add ${SKIP_TOKEN} to it to opt out explicitly. Never manufacture filler — an empty block is the correct outcome for a session that didn't deliberate.
 
-Otherwise, re-run your original command with the surviving block included in ${c.where}.`;
+Otherwise, re-run your original command with the surviving block included in ${c.where}.${c.rerunTrap}`;
 }
 
 /**


### PR DESCRIPTION
The hook blocks the **entire** tool call. If that call both wrote the body file and ran `gh pr create` — a heredoc chained to the command, which is a common shape — the file is never written.

The obvious repair is "add the block and re-run". That appends the block with `>>` to a file that does not exist, creating one that holds **only** the block. `gh pr create` then succeeds, and the pull request opens with the reasoning block as its entire description. No step reports an error.

Two real pull requests shipped that way before anyone noticed, each with a single character outside the markers. The block is meant to be an addition to the description; a denial that silently produces a replacement defeats the tool.

## What changes

The PR-surface guidance now ends with a warning: the denial blocked the whole command, so write the body file in a separate command from `gh pr create` and check its size before creating. It also states plainly that the block is an addition, never a replacement.

## Deliberately PR-only

A commit message is re-authored on the retry, so there is no half-written artifact to lose. `rerunTrap` is empty for that surface, and a test asserts the warning is **absent** from commit guidance — otherwise the PR-only warning quietly becomes boilerplate on every surface, which is how guidance text stops being read.

## The assertions can fail

With `${c.rerunTrap}` removed from the emitted string the suite goes 9 pass / 1 fail; restored, 10 / 0. Full suite 78/78, bundle rebuilt and in sync.

<!-- backthread:why -->
## Reasoning
<sub>written by the agent in-session via [`backthread/add-reasoning-to-prs`](https://github.com/backthread/add-reasoning-to-prs)</sub>

**Decisions**
- The warning is attached to the PR surface only, through a `rerunTrap` field that is empty for commits, rather than appended to the shared guidance text. A warning that appears where it cannot apply trains the reader to skim the whole block.

**Trade-offs**
- This lengthens a denial message that is already long, and the model reads all of it. Accepted because the failure it prevents is silent: the command succeeds and the pull request looks fine.

**Limitations**
- This is guidance, not enforcement. The hook still cannot see whether the body file survived, so a model that ignores the warning produces the same broken description. Detecting it properly would mean the hook inspecting the `--body-file` path at deny time, which is not attempted here.

<sub>↳ generated by [`backthread/add-reasoning-to-prs`](https://github.com/backthread/add-reasoning-to-prs) · an open-source Claude Code hook · edit or delete freely</sub>
<!-- /backthread:why -->
